### PR TITLE
Add initial dummy tests for service methods

### DIFF
--- a/Cooperator-Backend/src/test/java/ca/mcgill/cooperator/service/CooperatorServiceAdminTests.java
+++ b/Cooperator-Backend/src/test/java/ca/mcgill/cooperator/service/CooperatorServiceAdminTests.java
@@ -1,0 +1,56 @@
+package ca.mcgill.cooperator.service;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+public class CooperatorServiceAdminTests {
+	
+	// TODO: add Service and Repository class imports here
+
+	@BeforeEach
+	@AfterEach
+	public void clearDatabase() {
+		// TODO: clear every repository here
+	}
+	
+	@Test
+	public void testCreateAdmin() {
+		assertTrue(true);
+	}
+	
+	@Test
+	public void testCreateAdminNull() {
+		assertTrue(true);
+	}
+	
+	@Test
+	public void testCreateAdminEmpty() {
+		assertTrue(true);
+	}
+	
+	@Test
+	public void testCreateAdminSpaces() {
+		assertTrue(true);
+	}
+	
+	@Test
+	public void testUpdateAdmin() {
+		assertTrue(true);
+	}
+	
+	@Test
+	public void testUpdateAdminInvalid() {
+		assertTrue(true);
+	}
+	
+	@Test
+	public void testDeleteAdmin() {
+		assertTrue(true);
+	}
+	
+}

--- a/Cooperator-Backend/src/test/java/ca/mcgill/cooperator/service/CooperatorServiceCompanyTests.java
+++ b/Cooperator-Backend/src/test/java/ca/mcgill/cooperator/service/CooperatorServiceCompanyTests.java
@@ -1,0 +1,56 @@
+package ca.mcgill.cooperator.service;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+public class CooperatorServiceCompanyTests {
+
+	// TODO: add Service and Repository class imports here
+
+	@BeforeEach
+	@AfterEach
+	public void clearDatabase() {
+		// TODO: clear every repository here
+	}
+	
+	@Test
+	public void testCreateCompany() {
+		assertTrue(true);
+	}
+	
+	@Test
+	public void testCreateCompanyNull() {
+		assertTrue(true);
+	}
+	
+	@Test
+	public void testCreateCompanyEmpty() {
+		assertTrue(true);
+	}
+	
+	@Test
+	public void testCreateCompanySpaces() {
+		assertTrue(true);
+	}
+	
+	@Test
+	public void testUpdateCompany() {
+		assertTrue(true);
+	}
+	
+	@Test
+	public void testUpdateCompanyInvalid() {
+		assertTrue(true);
+	}
+	
+	@Test
+	public void testDeleteCompany() {
+		assertTrue(true);
+	}
+	
+}

--- a/Cooperator-Backend/src/test/java/ca/mcgill/cooperator/service/CooperatorServiceCoopDetailsTests.java
+++ b/Cooperator-Backend/src/test/java/ca/mcgill/cooperator/service/CooperatorServiceCoopDetailsTests.java
@@ -1,0 +1,61 @@
+package ca.mcgill.cooperator.service;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+public class CooperatorServiceCoopDetailsTests {
+
+	// TODO: add Service and Repository class imports here
+
+	@BeforeEach
+	@AfterEach
+	public void clearDatabase() {
+		// TODO: clear every repository here
+	}
+	
+	@Test
+	public void testCreateCoopDetails() {
+		assertTrue(true);
+	}
+	
+	@Test
+	public void testCreateCoopDetailsNull() {
+		assertTrue(true);
+	}
+	
+	@Test
+	public void testCreateCoopDetailsEmpty() {
+		assertTrue(true);
+	}
+	
+	@Test
+	public void testCreateCoopDetailsSpaces() {
+		assertTrue(true);
+	}
+	
+	@Test
+	public void testCreateCoopDetailsInvalid() {
+		assertTrue(true);
+	}
+	
+	@Test
+	public void testUpdateCoopDetails() {
+		assertTrue(true);
+	}
+	
+	@Test
+	public void testUpdateCoopDetailsInvalid() {
+		assertTrue(true);
+	}
+	
+	@Test
+	public void testDeleteCoopDetails() {
+		assertTrue(true);
+	}
+	
+}

--- a/Cooperator-Backend/src/test/java/ca/mcgill/cooperator/service/CooperatorServiceCoopTests.java
+++ b/Cooperator-Backend/src/test/java/ca/mcgill/cooperator/service/CooperatorServiceCoopTests.java
@@ -1,0 +1,56 @@
+package ca.mcgill.cooperator.service;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+public class CooperatorServiceCoopTests {
+	
+	// TODO: add Service and Repository class imports here
+
+	@BeforeEach
+	@AfterEach
+	public void clearDatabase() {
+		// TODO: clear every repository here
+	}
+	
+	@Test
+	public void testCreateCoop() {
+		assertTrue(true);
+	}
+	
+	@Test
+	public void testCreateCoopNull() {
+		assertTrue(true);
+	}
+	
+	@Test
+	public void testCreateCoopEmpty() {
+		assertTrue(true);
+	}
+	
+	@Test
+	public void testCreateCoopSpaces() {
+		assertTrue(true);
+	}
+	
+	@Test
+	public void testUpdateCoop() {
+		assertTrue(true);
+	}
+	
+	@Test
+	public void testUpdateCoopInvalid() {
+		assertTrue(true);
+	}
+	
+	@Test
+	public void testDeleteCoop() {
+		assertTrue(true);
+	}
+
+}

--- a/Cooperator-Backend/src/test/java/ca/mcgill/cooperator/service/CooperatorServiceCourseOfferingTests.java
+++ b/Cooperator-Backend/src/test/java/ca/mcgill/cooperator/service/CooperatorServiceCourseOfferingTests.java
@@ -1,0 +1,56 @@
+package ca.mcgill.cooperator.service;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+public class CooperatorServiceCourseOfferingTests {
+	
+	// TODO: add Service and Repository class imports here
+
+	@BeforeEach
+	@AfterEach
+	public void clearDatabase() {
+		// TODO: clear every repository here
+	}
+	
+	@Test
+	public void testCreateCourseOffering() {
+		assertTrue(true);
+	}
+	
+	@Test
+	public void testCreateCourseOfferingNull() {
+		assertTrue(true);
+	}
+	
+	@Test
+	public void testCreateCourseOfferingEmpty() {
+		assertTrue(true);
+	}
+	
+	@Test
+	public void testCreateCourseOfferingSpaces() {
+		assertTrue(true);
+	}
+	
+	@Test
+	public void testUpdateCourseOffering() {
+		assertTrue(true);
+	}
+	
+	@Test
+	public void testUpdateCourseOfferingInvalid() {
+		assertTrue(true);
+	}
+	
+	@Test
+	public void testDeleteCourseOffering() {
+		assertTrue(true);
+	}
+	
+}

--- a/Cooperator-Backend/src/test/java/ca/mcgill/cooperator/service/CooperatorServiceCourseTests.java
+++ b/Cooperator-Backend/src/test/java/ca/mcgill/cooperator/service/CooperatorServiceCourseTests.java
@@ -1,0 +1,56 @@
+package ca.mcgill.cooperator.service;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+public class CooperatorServiceCourseTests {
+	
+	// TODO: add Service and Repository class imports here
+
+	@BeforeEach
+	@AfterEach
+	public void clearDatabase() {
+		// TODO: clear every repository here
+	}
+	
+	@Test
+	public void testCreateCourse() {
+		assertTrue(true);
+	}
+	
+	@Test
+	public void testCreateCourseNull() {
+		assertTrue(true);
+	}
+	
+	@Test
+	public void testCreateCourseEmpty() {
+		assertTrue(true);
+	}
+	
+	@Test
+	public void testCreateCourseSpaces() {
+		assertTrue(true);
+	}
+	
+	@Test
+	public void testUpdateCourse() {
+		assertTrue(true);
+	}	
+	
+	@Test
+	public void testUpdateCourseInvalid() {
+		assertTrue(true);
+	}
+	
+	@Test
+	public void testDeleteCourse() {
+		assertTrue(true);
+	}
+	
+}

--- a/Cooperator-Backend/src/test/java/ca/mcgill/cooperator/service/CooperatorServiceEmployerContactTests.java
+++ b/Cooperator-Backend/src/test/java/ca/mcgill/cooperator/service/CooperatorServiceEmployerContactTests.java
@@ -1,0 +1,59 @@
+package ca.mcgill.cooperator.service;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class CooperatorServiceEmployerContactTests {
+
+	// TODO: add Service and Repository class imports here
+
+	@BeforeEach
+	@AfterEach
+	public void clearDatabase() {
+		// TODO: clear every repository here
+	}
+	
+	@Test
+	public void testCreateEmployerContact() {
+		assertTrue(true);
+	}
+	
+	@Test
+	public void testCreateEmployerContactNull() {
+		assertTrue(true);
+	}
+	
+	@Test
+	public void testCreateEmployerContactEmpty() {
+		assertTrue(true);
+	}
+	
+	@Test
+	public void testCreateEmployerContactSpaces() {
+		assertTrue(true);
+	}
+	
+	@Test
+	public void testCreateEmployerContactWithCoopDetails() {
+		assertTrue(true);
+	}
+	
+	@Test
+	public void testUpdateEmployerContact() {
+		assertTrue(true);
+	}
+	
+	@Test
+	public void testUpdateEmployerContactInvalid() {
+		assertTrue(true);
+	}
+	
+	@Test
+	public void testDeleteEmployerContact() {
+		assertTrue(true);
+	}
+	
+}

--- a/Cooperator-Backend/src/test/java/ca/mcgill/cooperator/service/CooperatorServiceNotificationTests.java
+++ b/Cooperator-Backend/src/test/java/ca/mcgill/cooperator/service/CooperatorServiceNotificationTests.java
@@ -1,0 +1,66 @@
+package ca.mcgill.cooperator.service;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+public class CooperatorServiceNotificationTests {
+	
+	// TODO: add Service and Repository class imports here
+
+	@BeforeEach
+	@AfterEach
+	public void clearDatabase() {
+		// TODO: clear every repository here
+	}
+	
+	@Test
+	public void testCreateNotification() {
+		assertTrue(true);
+	}
+	
+	@Test
+	public void testCreateNotificationNull() {
+		assertTrue(true);
+	}
+	
+	@Test
+	public void testCreateNotificationEmpty() {
+		assertTrue(true);
+	}
+	
+	@Test
+	public void testCreateNotificationSpaces() {
+		assertTrue(true);
+	}
+	
+	@Test
+	public void testCreateNotificationOneStudent() {
+		assertTrue(true);
+	}
+	
+	@Test
+	public void testCreateNotificationManyStudents() {
+		assertTrue(true);
+	}
+	
+	@Test
+	public void testUpdateNotification() {
+		assertTrue(true);
+	}
+	
+	@Test
+	public void testUpdateNotificationInvalid() {
+		assertTrue(true);
+	}
+	
+	@Test
+	public void testDeleteNotification() {
+		assertTrue(true);
+	}
+	
+}

--- a/Cooperator-Backend/src/test/java/ca/mcgill/cooperator/service/CooperatorServiceStudentTests.java
+++ b/Cooperator-Backend/src/test/java/ca/mcgill/cooperator/service/CooperatorServiceStudentTests.java
@@ -1,0 +1,56 @@
+package ca.mcgill.cooperator.service;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+public class CooperatorServiceStudentTests {
+
+	// TODO: add Service and Repository class imports here
+	
+	@BeforeEach
+	@AfterEach
+	public void clearDatabase() {
+		// TODO: clear every Repository here
+	}
+	
+	@Test
+	public void testCreateStudent() {
+		assertTrue(true);
+	}
+	
+	@Test
+	public void testCreateStudentNull() {
+		assertTrue(true);
+	}
+	
+	@Test
+	public void testCreateStudentEmpty() {
+		assertTrue(true);
+	}
+	
+	@Test
+	public void testCreateStudentSpaces() {
+		assertTrue(true);
+	}
+	
+	@Test
+	public void testUpdateStudent() {
+		assertTrue(true);
+	}
+	
+	@Test
+	public void testUpdateStudentInvalid() {
+		assertTrue(true);
+	}
+	
+	@Test
+	public void testDeleteStudent() {
+		assertTrue(true);
+	}
+	
+}


### PR DESCRIPTION
# Summary

Added dummy tests that simply do `assertTrue(true)` in order to pass. The test names serve as a template that say what that test should eventually be testing. We can use this to get started with writing tests for the service class methods.

## Test Plan

`mvn test` 

## Related Issues

#12 
