### PR TITLE
Remove constructors from all model classes

### DIFF
--- a/Cooperator-Backend/src/main/java/ca/mcgill/cooperator/model/Admin.java
+++ b/Cooperator-Backend/src/main/java/ca/mcgill/cooperator/model/Admin.java
@@ -17,15 +17,6 @@ public class Admin {
     @OneToMany(mappedBy = "sender", fetch = FetchType.EAGER)
     private List<Notification> sent;
 
-    /*--- Constructors ---*/
-
-    public Admin(String firstName, String lastName, String email, List<Notification> sent) {
-        this.firstName = firstName;
-        this.lastName = lastName;
-        this.email = email;
-        this.sent = sent;
-    }
-
     /*--- Getters and Setters ---*/
 
     public int getId() {

--- a/Cooperator-Backend/src/main/java/ca/mcgill/cooperator/model/Company.java
+++ b/Cooperator-Backend/src/main/java/ca/mcgill/cooperator/model/Company.java
@@ -14,13 +14,6 @@ public class Company {
     @OneToMany(mappedBy = "company")
     private List<EmployerContact> employees;
 
-    /*--- Constructors ---*/
-
-    public Company(String name, List<EmployerContact> employees) {
-        this.name = name;
-        this.employees = employees;
-    }
-
     /*--- Getters and Setters ---*/
 
     public int getId() {

--- a/Cooperator-Backend/src/main/java/ca/mcgill/cooperator/model/Coop.java
+++ b/Cooperator-Backend/src/main/java/ca/mcgill/cooperator/model/Coop.java
@@ -28,23 +28,6 @@ public class Coop {
     @OneToMany(mappedBy = "coop")
     private List<EmployerReport> employerReports;
 
-    /*--- Constructors ---*/
-
-    public Coop(
-            CoopStatus status,
-            CourseOffering courseOffering,
-            CoopDetails details,
-            Student student,
-            List<StudentReport> studentReports,
-            List<EmployerReport> employerReports) {
-        this.status = status;
-        this.courseOffering = courseOffering;
-        this.details = details;
-        this.student = student;
-        this.studentReports = studentReports;
-        this.employerReports = employerReports;
-    }
-
     /*--- Getters and Setters ---*/
 
     public int getId() {

--- a/Cooperator-Backend/src/main/java/ca/mcgill/cooperator/model/CoopDetails.java
+++ b/Cooperator-Backend/src/main/java/ca/mcgill/cooperator/model/CoopDetails.java
@@ -17,16 +17,6 @@ public class CoopDetails {
 
     @OneToOne private Coop coop;
 
-    /*--- Constructors ---*/
-
-    public CoopDetails(
-            double payPerHour, int hoursPerWeek, EmployerContact employerContact, Coop coop) {
-        this.payPerHour = payPerHour;
-        this.hoursPerWeek = hoursPerWeek;
-        this.employerContact = employerContact;
-        this.coop = coop;
-    }
-
     /*--- Getters and Setters ---*/
 
     public int getId() {

--- a/Cooperator-Backend/src/main/java/ca/mcgill/cooperator/model/Course.java
+++ b/Cooperator-Backend/src/main/java/ca/mcgill/cooperator/model/Course.java
@@ -14,13 +14,6 @@ public class Course {
     @OneToMany(mappedBy = "course")
     private List<CourseOffering> courseOfferings;
 
-    /*--- Constructors ---*/
-
-    public Course(String name, List<CourseOffering> courseOfferings) {
-        this.name = name;
-        this.courseOfferings = courseOfferings;
-    }
-
     /*--- Getters and Setters ---*/
 
     public int getId() {

--- a/Cooperator-Backend/src/main/java/ca/mcgill/cooperator/model/CourseOffering.java
+++ b/Cooperator-Backend/src/main/java/ca/mcgill/cooperator/model/CourseOffering.java
@@ -19,15 +19,6 @@ public class CourseOffering {
     @OneToMany(mappedBy = "courseOffering")
     private List<Coop> coops;
 
-    /*--- Constructors ---*/
-
-    public CourseOffering(int year, Season season, Course course, List<Coop> coops) {
-        this.year = year;
-        this.season = season;
-        this.course = course;
-        this.coops = coops;
-    }
-
     /*--- Getters and Setters ---*/
 
     public int getId() {

--- a/Cooperator-Backend/src/main/java/ca/mcgill/cooperator/model/EmployerContact.java
+++ b/Cooperator-Backend/src/main/java/ca/mcgill/cooperator/model/EmployerContact.java
@@ -23,25 +23,6 @@ public class EmployerContact {
     @OneToMany(mappedBy = "employerContact")
     private List<EmployerReport> employerReports;
 
-    /*--- Constructors ---*/
-
-    public EmployerContact(
-            String email,
-            String firstName,
-            String lastName,
-            String phoneNumber,
-            Company company,
-            List<CoopDetails> coopDetails,
-            List<EmployerReport> employerReports) {
-        this.email = email;
-        this.firstName = firstName;
-        this.lastName = lastName;
-        this.phoneNumber = phoneNumber;
-        this.company = company;
-        this.coopdetails = coopDetails;
-        this.employerReports = employerReports;
-    }
-
     /*--- Getters and Setters ---*/
 
     public int getId() {

--- a/Cooperator-Backend/src/main/java/ca/mcgill/cooperator/model/EmployerReport.java
+++ b/Cooperator-Backend/src/main/java/ca/mcgill/cooperator/model/EmployerReport.java
@@ -18,19 +18,6 @@ public class EmployerReport {
 
     @OneToMany private List<ReportSection> reportSections;
 
-    /*--- Constructors ---*/
-
-    public EmployerReport(
-            Coop coop,
-            EmployerContact employerContact,
-            List<ReportSection> reportSections,
-            ReportStatus reportStatus) {
-        this.coop = coop;
-        this.employerContact = employerContact;
-        this.reportSections = reportSections;
-        this.status = reportStatus;
-    }
-
     /*--- Getters and Setters ---*/
 
     public int getId() {

--- a/Cooperator-Backend/src/main/java/ca/mcgill/cooperator/model/Notification.java
+++ b/Cooperator-Backend/src/main/java/ca/mcgill/cooperator/model/Notification.java
@@ -16,15 +16,6 @@ public class Notification {
     @ManyToOne(optional = false)
     private Admin sender;
 
-    /*--- Constructors ---*/
-
-    public Notification(String title, String body, Student student, Admin sender) {
-        this.title = title;
-        this.body = body;
-        this.student = student;
-        this.sender = sender;
-    }
-
     /*--- Setters and Getters ---*/
 
     public int getId() {

--- a/Cooperator-Backend/src/main/java/ca/mcgill/cooperator/model/ReportSection.java
+++ b/Cooperator-Backend/src/main/java/ca/mcgill/cooperator/model/ReportSection.java
@@ -17,16 +17,6 @@ public class ReportSection {
     @ManyToOne(optional = true)
     private EmployerReport employerReport;
 
-    /*--- Constructors ---*/
-
-    public ReportSection(
-            String title, String content, StudentReport stuReport, EmployerReport employerReport) {
-        this.title = title;
-        this.content = content;
-        this.studentReport = stuReport;
-        this.employerReport = employerReport;
-    }
-
     /*--- Getters and Setters ---*/
 
     public int getId() {

--- a/Cooperator-Backend/src/main/java/ca/mcgill/cooperator/model/Student.java
+++ b/Cooperator-Backend/src/main/java/ca/mcgill/cooperator/model/Student.java
@@ -21,23 +21,6 @@ public class Student {
     @OneToMany(mappedBy = "student", fetch = FetchType.EAGER)
     private List<Notification> studentReceived;
 
-    /*--- Constructors ---*/
-
-    public Student(
-            String firstName,
-            String lastName,
-            String email,
-            String studentId,
-            List<Coop> coops,
-            List<Notification> notifications) {
-        this.firstName = firstName;
-        this.lastName = lastName;
-        this.email = email;
-        this.studentId = studentId;
-        this.coops = coops;
-        this.studentReceived = notifications;
-    }
-
     /*--- Getters and Setters ---*/
 
     public int getId() {

--- a/Cooperator-Backend/src/main/java/ca/mcgill/cooperator/model/StudentReport.java
+++ b/Cooperator-Backend/src/main/java/ca/mcgill/cooperator/model/StudentReport.java
@@ -16,14 +16,6 @@ public class StudentReport {
 
     @OneToMany private List<ReportSection> reportSections;
 
-    /*--- Constructors ---*/
-
-    public StudentReport(Coop coop, List<ReportSection> reportSections, ReportStatus status) {
-        this.coop = coop;
-        this.reportSections = reportSections;
-        this.status = status;
-    }
-
     /*--- Getters and Setters ---*/
 
     public int getId() {


### PR DESCRIPTION
# Summary

By removing the explicit constructors in each domain model class, we can create instances with the default constructor and then set their attributes with the classes's setter functions. This is how we implemented the domain model classes in ECSE 321. 

## Test Plan

`mvn test`

## Related Issues

N/A, fix
