### PR TITLE
Fix error with test profile when running application

### DIFF
--- a/Cooperator-Backend/src/main/java/ca/mcgill/cooperator/config/TestDataSourceConfig.java
+++ b/Cooperator-Backend/src/main/java/ca/mcgill/cooperator/config/TestDataSourceConfig.java
@@ -9,11 +9,11 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.context.annotation.PropertySource;
 
 @Configuration
+@Profile("test")
 @PropertySource("classpath:application-test.properties")
 public class TestDataSourceConfig {
 
     @Bean
-    @Profile("test")
     public DataSource getTestDataSource() {
         Dotenv dotenv = Dotenv.configure().ignoreIfMissing().load();
 


### PR DESCRIPTION
# Summary

Moved the `@Profile` annotation to the class level in the test datasource config so that everything below that annotation would only run if tests are being run. With the annotation in its old location, the app would fail to run since the `application-test.properties` file could not be found in the classpath.

## Test Plan

`mvn test` and tested by making sure the app runs as expected.

## Related Issues

N/A
