### PR TITLE
Basic setup for Cucumber

### DIFF
--- a/Backend/pom.xml
+++ b/Backend/pom.xml
@@ -37,17 +37,29 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
-			<exclusions>
-				<exclusion>
-					<groupId>org.junit.vintage</groupId>
-					<artifactId>junit-vintage-engine</artifactId>
-				</exclusion>
-			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>io.github.cdimascio</groupId>
 			<artifactId>java-dotenv</artifactId>
 			<version>5.1.3</version>
+		</dependency>
+		<dependency>
+		  <groupId>io.cucumber</groupId>
+		  <artifactId>cucumber-java8</artifactId>
+		  <version>4.8.0</version>
+		  <scope>test</scope>
+		</dependency>
+		<dependency>
+		  <groupId>io.cucumber</groupId>
+		  <artifactId>cucumber-spring</artifactId>
+		  <version>4.8.0</version>
+		  <scope>test</scope>
+		</dependency>
+		<dependency>
+		  <groupId>io.cucumber</groupId>
+		  <artifactId>cucumber-junit</artifactId>
+		  <version>4.8.0</version>
+		  <scope>test</scope>
 		</dependency>
 	</dependencies>
 

--- a/Backend/src/test/java/ca/mcgill/cooperator/cucumber/AdminApproveCoopIT.java
+++ b/Backend/src/test/java/ca/mcgill/cooperator/cucumber/AdminApproveCoopIT.java
@@ -1,0 +1,23 @@
+package ca.mcgill.cooperator.cucumber;
+
+import static org.junit.Assert.assertTrue;
+
+import org.springframework.test.context.ActiveProfiles;
+
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+
+@ActiveProfiles("test")
+public class AdminApproveCoopIT {
+	
+	@When("the Student submits their offer letter")
+	public void studentSubmitsOfferLetter() {
+		assertTrue(true);
+	}
+	
+	@Then("the Admin approves the Coop term")
+	public void adminApprovesCoopTerm() {
+		assertTrue(true);
+	}
+	
+}

--- a/Backend/src/test/java/ca/mcgill/cooperator/cucumber/CucumberIT.java
+++ b/Backend/src/test/java/ca/mcgill/cooperator/cucumber/CucumberIT.java
@@ -1,0 +1,15 @@
+package ca.mcgill.cooperator.cucumber;
+
+import org.junit.runner.RunWith;
+
+import io.cucumber.junit.Cucumber;
+import io.cucumber.junit.CucumberOptions;
+
+/**
+ * Configuration for Cucumber tests
+ */
+@RunWith(Cucumber.class)
+@CucumberOptions(features = "classpath:features", plugin = {"pretty", "json:target/cucumber-report.json"})
+public class CucumberIT {
+
+}

--- a/Backend/src/test/resources/features/admin_approve_coop.feature
+++ b/Backend/src/test/resources/features/admin_approve_coop.feature
@@ -1,0 +1,4 @@
+Feature: the Admin can approve or deny a Student's Coop term
+    Scenario: Admin approves Coop term
+        When the Student submits their offer letter
+        Then the Admin approves the Coop term


### PR DESCRIPTION
# Summary

Basic setup for Cucumber acceptance tests.
* `mvn failsafe:integration-test` will now run both the integration tests and Cucumber tests
* Removed exclusion for JUnit Vintage in the Maven `pom.xml` since Cucumber does not have full support for JUnit 5 yet, so JUnit Vintage is required to run the Cucumber tests

## Test Plan

`mvn failsafe:integration-test`

Output:
```java
[INFO] Running ca.mcgill.cooperator.cucumber.CucumberIT
2020-01-16 22:11:08.929  INFO 87644 --- [           main] c.runtime.java.ObjectFactoryLoader       : Loading ObjectFactory via service loader: io.cucumber.spring.SpringFactory
Feature: the Admin can approve or deny a Student's Coop term

  Scenario: Admin approves Coop term            # features/admin_approve_coop.feature:2
    When the Student submits their offer letter # AdminApproveCoopIT.studentSubmitsOfferLetter()
    Then the Admin approves the Coop term       # AdminApproveCoopIT.adminApprovesCoopTerm()
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.095 s - in ca.mcgill.cooperator.cucumber.CucumberIT
```

## Related Issues

#28 
