### PR TITLE
Implement dummy logged-in user storage

### DIFF
--- a/Frontend/src/boot/axios.js
+++ b/Frontend/src/boot/axios.js
@@ -1,4 +1,16 @@
-import Vue from 'vue'
-import axios from 'axios'
+import Vue from "vue";
+import axios from "axios";
 
-Vue.prototype.$axios = axios
+var config = require("../config");
+
+// Axios config
+const frontendUrl = config.build.host + ":" + config.build.port;
+const backendUrl = config.build.backendHost + ":" + config.build.backendPort;
+
+Vue.prototype.$axios = axios.create({
+  baseURL: backendUrl,
+  headers: {
+    "Access-Control-Allow-Origin": frontendUrl,
+    "Content-Type": "application/json"
+  }
+});

--- a/Frontend/src/config/index.js
+++ b/Frontend/src/config/index.js
@@ -1,0 +1,38 @@
+var path = require("path");
+
+module.exports = {
+  build: {
+    host: process.env.NODE_ENV === "development" ? "http://127.0.0.1" : "",
+    port: process.env.NODE_ENV === "development" ? 8080 : 443,
+    backendHost:
+      process.env.NODE_ENV === "development" ? "http://127.0.0.1" : "",
+    backendPort: process.env.NODE_ENV === "development" ? 8081 : 443,
+    index: path.resolve(__dirname, "../dist/index.html"),
+    assetsRoot: path.resolve(__dirname, "../dist"),
+    assetsSubDirectory: "static",
+    assetsPublicPath: "/",
+    productionSourceMap: true,
+    // Gzip off by default as many popular static hosts such as
+    // Surge or Netlify already gzip all static assets for you.
+    // Before setting to `true`, make sure to:
+    // npm install --save-dev compression-webpack-plugin
+    productionGzip: false,
+    productionGzipExtensions: ["js", "css"]
+  },
+  dev: {
+    host: "127.0.0.1",
+    port: 8081,
+    backendHost: "127.0.0.1",
+    backendPort: 5000,
+    autoOpenBrowser: true,
+    assetsSubDirectory: "static",
+    assetsPublicPath: "/",
+    proxyTable: {},
+    // CSS Sourcemaps off by default because relative paths are "buggy"
+    // with this option, according to the CSS-Loader README
+    // (https://github.com/webpack/css-loader#sourcemaps)
+    // In our experience, they generally work as expected,
+    // just be aware of this issue when enabling this option.
+    cssSourceMap: false
+  }
+};

--- a/Frontend/src/router/index.js
+++ b/Frontend/src/router/index.js
@@ -1,16 +1,32 @@
-import Vue from 'vue'
-import VueRouter from 'vue-router'
+import Vue from "vue";
+import VueRouter from "vue-router";
 
-import routes from './routes'
+import axios from "axios";
+import routes from "./routes";
+import Store from "../store";
 
-Vue.use(VueRouter)
+Vue.use(VueRouter);
+
+var config = require("../config");
+
+// Axios config
+const frontendUrl = config.build.host + ":" + config.build.port;
+const backendUrl = config.build.backendHost + ":" + config.build.backendPort;
+
+var AXIOS = axios.create({
+  baseURL: backendUrl,
+  headers: {
+    "Access-Control-Allow-Origin": frontendUrl,
+    "Content-Type": "application/json"
+  }
+});
 
 /*
  * If not building with SSR mode, you can
  * directly export the Router instantiation
  */
 
-export default function (/* { store, ssrContext } */) {
+export default function(/* { store, ssrContext } */) {
   const Router = new VueRouter({
     scrollBehavior: () => ({ x: 0, y: 0 }),
     routes,
@@ -20,7 +36,73 @@ export default function (/* { store, ssrContext } */) {
     // quasar.conf.js -> build -> publicPath
     mode: process.env.VUE_ROUTER_MODE,
     base: process.env.VUE_ROUTER_BASE
-  })
+  });
 
-  return Router
+  Router.beforeEach((to, from, next) => {
+    if (to.matched.some(record => record.meta.requiresStudentAuth)) {
+      // this route requires Student auth, check if logged in
+      if (!Store.getters.isLoggedIn || Store.state.userType !== "student") {
+        console.log("Not logged in or wrong user type for this page");
+        next({
+          path: "/login",
+          query: { redirect: to.fullPath }
+        });
+      } else if (Store.getters.isLoggedIn && !Store.state.userExists) {
+        console.log("User ID specified, but no current user in Store");
+        // get user with stored ID
+        AXIOS.get("/students/" + Store.state.userId)
+          .then(resp => {
+            Store.commit("set_user", resp.data);
+            next();
+          })
+          .catch(() => {
+            // user not found
+            Store.dispatch("logout").then(
+              next({
+                path: "/login",
+                query: { redirect: to.fullPath }
+              })
+            );
+            next();
+          });
+      } else {
+        console.log("Logged in properly");
+        next();
+      }
+    } else if (to.matched.some(record => record.meta.requiresAdminAuth)) {
+      // this route requires Admin auth, check if logged in
+      if (!Store.getters.isLoggedIn || Store.state.userType !== "admin") {
+        console.log("Not logged in or wrong user type for this page");
+        next({
+          path: "/login",
+          query: { redirect: to.fullPath }
+        });
+      } else if (Store.getters.isLoggedIn && !Store.state.userExists) {
+        console.log("User ID specified, but no current user in Store");
+        // get user with stored ID
+        AXIOS.get("/admins/" + Store.state.userId)
+          .then(resp => {
+            Store.commit("set_user", resp.data);
+            next();
+          })
+          .catch(() => {
+            // user not found
+            Store.dispatch("logout").then(
+              next({
+                path: "/login",
+                query: { redirect: to.fullPath }
+              })
+            );
+            next();
+          });
+      } else {
+        console.log("Logged in properly");
+        next();
+      }
+    } else {
+      next(); // always call next()
+    }
+  });
+
+  return Router;
 }

--- a/Frontend/src/router/routes.js
+++ b/Frontend/src/router/routes.js
@@ -2,6 +2,7 @@ const routes = [
   {
     path: "/student",
     component: () => import("layouts/StudentLoggedInLayout.vue"),
+    meta: { requiresStudentAuth: true },
     children: [
       { path: "", redirect: "home" },
       {
@@ -30,6 +31,7 @@ const routes = [
   {
     path: "/admin",
     component: () => import("layouts/AdminLoggedInLayout.vue"),
+    meta: { requiresAdminAuth: true },
     children: [
       { path: "", redirect: "home" },
       { path: "home", component: () => import("pages/admin/AdminHome.vue") },

--- a/Frontend/src/store/index.js
+++ b/Frontend/src/store/index.js
@@ -1,25 +1,74 @@
-import Vue from 'vue'
-import Vuex from 'vuex'
+import Vue from "vue";
+import Vuex from "vuex";
 
 // import example from './module-example'
 
-Vue.use(Vuex)
+Vue.use(Vuex);
 
 /*
  * If not building with SSR mode, you can
  * directly export the Store instantiation
  */
 
-export default function (/* { ssrContext } */) {
-  const Store = new Vuex.Store({
-    modules: {
-      // example
+const Store = new Vuex.Store({
+  state: {
+    status: "",
+    token: localStorage.getItem("token") || "", // not used currently
+    userId: localStorage.getItem("userId") || "",
+    currentUser: {},
+    userExists: false,
+    userType: localStorage.getItem("userType") || "" // admin or student
+  },
+  getters: {
+    isLoggedIn: state => !!state.userId,
+    authStatus: state => state.status
+  },
+  mutations: {
+    auth_request(state) {
+      state.status = "loading";
     },
+    auth_success(state, authObj) {
+      state.status = "success";
+      state.token = authObj.token;
+      state.currentUser = authObj.user;
+      state.userExists = true;
+    },
+    auth_error(state) {
+      state.status = "error";
+    },
+    logout(state) {
+      state.status = "";
+      state.token = "";
+      state.currentUser = {};
+      state.userExists = false;
+      state.userId = "";
+      state.userType = "";
+    },
+    set_user(state, user) {
+      state.currentUser = user;
+      state.userExists = true;
+    }
+  },
+  actions: {
+    // TODO: these are unimplemented
+    login({ commit }, user) {
+      return new Promise((resolve, reject) => {
+        resolve();
+      });
+    },
+    logout({ commit }) {
+      return new Promise((resolve, reject) => {
+        resolve();
+      });
+    }
+  },
+  modules: {
+    // example
+  },
 
-    // enable strict mode (adds overhead!)
-    // for dev mode only
-    strict: process.env.DEV
-  })
+  // enable strict mode (adds overhead!)
+  // for dev mode only
+  strict: process.env.DEV
+});
 
-  return Store
-}
+export default Store;


### PR DESCRIPTION
# Summary

Since we aren't able to implement real logins quite yet, this is a temporary solution that allows the frontend to keep track of a logged-in user (so that we can test things that require a specific user to be logged in).

To get set up, define two variables in local storage: `userId` and `userType`. `userId` should be the ID of an existing Student or Admin in the database, and `userType` should be either `student` or `admin`. This information represents which user is logged in, and also what type of user they are.

Also set up a global Axios variable, which can be accessed in any component as `this.$axios`. This way, an Axios variable doesn't need to be declared in every component that needs it.

## Test Plan

* Created a Student and Admin in my dev DB to test with
* Made sure that the userType restricted which pages could be accessed (e.g. a Student shouldn't be able to access any `/admin` pages)

Example local storage setup:
![Screen Shot 2020-02-17 at  Feb 17   10 10 00 PM](https://user-images.githubusercontent.com/25532617/74700684-52103f80-51d2-11ea-9c3e-47365e22425b.jpg)


## Related Issues

closes #93 
