### PR TITLE
Update error messages to include originating layer

### DIFF
--- a/Backend/src/main/java/ca/mcgill/cooperator/controller/ControllerUtils.java
+++ b/Backend/src/main/java/ca/mcgill/cooperator/controller/ControllerUtils.java
@@ -41,9 +41,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import org.springframework.stereotype.Component;
 
-@Component
 public class ControllerUtils {
 
     static final String ERROR_PREFIX = "ERROR [DTO Conversion]: ";
@@ -54,7 +52,7 @@ public class ControllerUtils {
 
     public static AdminDto convertToDto(Admin a) {
         if (a == null) {
-            throw new IllegalArgumentException("Admin does not exist!");
+            throw new IllegalArgumentException(ERROR_PREFIX + "Admin does not exist!");
         }
 
         AdminDto adminDto =
@@ -99,7 +97,7 @@ public class ControllerUtils {
 
         for (Admin a : admins) {
             if (a == null) {
-                throw new IllegalArgumentException("Admin does not exist!");
+                throw new IllegalArgumentException(ERROR_PREFIX + "Admin does not exist!");
             }
             adminDtos.add(convertToDto(a));
         }
@@ -109,7 +107,7 @@ public class ControllerUtils {
 
     public static CompanyDto convertToDto(Company c) {
         if (c == null) {
-            throw new IllegalArgumentException("Company does not exist!");
+            throw new IllegalArgumentException(ERROR_PREFIX + "Company does not exist!");
         }
 
         CompanyDto companyDto =
@@ -148,7 +146,7 @@ public class ControllerUtils {
 
         for (Company c : companies) {
             if (c == null) {
-                throw new IllegalArgumentException("Company does not exist!");
+                throw new IllegalArgumentException(ERROR_PREFIX + "Company does not exist!");
             }
             companyDtos.add(convertToDto(c));
         }
@@ -157,7 +155,7 @@ public class ControllerUtils {
 
     public static CoopDto convertToDto(Coop c) {
         if (c == null) {
-            throw new IllegalArgumentException("Coop does not exist!");
+            throw new IllegalArgumentException(ERROR_PREFIX + "Coop does not exist!");
         }
 
         // first make coop with null course offering and null student
@@ -314,7 +312,7 @@ public class ControllerUtils {
 
         for (Coop c : coops) {
             if (c == null) {
-                throw new IllegalArgumentException("Coop does not exist!");
+                throw new IllegalArgumentException(ERROR_PREFIX + "Coop does not exist!");
             }
             coopDtos.add(convertToDto(c));
         }
@@ -326,7 +324,7 @@ public class ControllerUtils {
 
         for (Coop c : coops) {
             if (c == null) {
-                throw new IllegalArgumentException("Coop does not exist!");
+                throw new IllegalArgumentException(ERROR_PREFIX + "Coop does not exist!");
             }
             coopDtos.add(convertToDto(c));
         }
@@ -335,7 +333,7 @@ public class ControllerUtils {
 
     public static CoopDetailsDto convertToDto(CoopDetails cd) {
         if (cd == null) {
-            throw new IllegalArgumentException("Coop details do not exist!");
+            throw new IllegalArgumentException(ERROR_PREFIX + "Coop details do not exist!");
         }
 
         CoopDetailsDto coopDetailsDto =
@@ -420,24 +418,13 @@ public class ControllerUtils {
         return coopDetailsDto;
     }
 
-    public static List<CoopDetailsDto> convertCoopDetailsListToDto(Set<CoopDetails> coopDetails) {
+    public static List<CoopDetailsDto> convertCoopDetailsListToDto(
+            Collection<CoopDetails> coopDetails) {
         List<CoopDetailsDto> coopDetailsDtos = new ArrayList<CoopDetailsDto>();
 
         for (CoopDetails cd : coopDetails) {
             if (cd == null) {
-                throw new IllegalArgumentException("Coop details do not exist!");
-            }
-            coopDetailsDtos.add(convertToDto(cd));
-        }
-        return coopDetailsDtos;
-    }
-
-    public static List<CoopDetailsDto> convertCoopDetailsListToDto(List<CoopDetails> coopDetails) {
-        List<CoopDetailsDto> coopDetailsDtos = new ArrayList<CoopDetailsDto>();
-
-        for (CoopDetails cd : coopDetails) {
-            if (cd == null) {
-                throw new IllegalArgumentException("Coop details do not exist!");
+                throw new IllegalArgumentException(ERROR_PREFIX + "Coop details do not exist!");
             }
             coopDetailsDtos.add(convertToDto(cd));
         }
@@ -446,7 +433,7 @@ public class ControllerUtils {
 
     public static CourseDto convertToDto(Course c) {
         if (c == null) {
-            throw new IllegalArgumentException("Course does not exist!");
+            throw new IllegalArgumentException(ERROR_PREFIX + "Course does not exist!");
         }
 
         CourseDto courseDto = new CourseDto(c.getId(), c.getName(), null); // null course offerings
@@ -477,7 +464,7 @@ public class ControllerUtils {
 
         for (Course c : courses) {
             if (c == null) {
-                throw new IllegalArgumentException("Course does not exist!");
+                throw new IllegalArgumentException(ERROR_PREFIX + "Course does not exist!");
             }
             courseDtos.add(convertToDto(c));
         }
@@ -486,7 +473,7 @@ public class ControllerUtils {
 
     public static CourseOfferingDto convertToDto(CourseOffering co) {
         if (co == null) {
-            throw new IllegalArgumentException("Course Offering does not exist!");
+            throw new IllegalArgumentException(ERROR_PREFIX + "Course Offering does not exist!");
         }
 
         // create course offering dto with null course
@@ -566,7 +553,8 @@ public class ControllerUtils {
 
         for (CourseOffering co : courseOfferings) {
             if (co == null) {
-                throw new IllegalArgumentException("Course Offering does not exist!");
+                throw new IllegalArgumentException(
+                        ERROR_PREFIX + "Course Offering does not exist!");
             }
             courseOfferingDtos.add(convertToDto(co));
         }
@@ -575,7 +563,7 @@ public class ControllerUtils {
 
     public static EmployerContactDto convertToDto(EmployerContact e) {
         if (e == null) {
-            throw new IllegalArgumentException("Employer Contact does not exist!");
+            throw new IllegalArgumentException(ERROR_PREFIX + "Employer Contact does not exist!");
         }
 
         // create employer contact dto
@@ -684,7 +672,8 @@ public class ControllerUtils {
         if (employerContacts != null) {
             for (EmployerContact ec : employerContacts) {
                 if (ec == null) {
-                    throw new IllegalArgumentException("Employer Contact does not exist!");
+                    throw new IllegalArgumentException(
+                            ERROR_PREFIX + "Employer Contact does not exist!");
                 }
                 employerContactDtos.add(convertToDto(ec));
             }
@@ -694,7 +683,7 @@ public class ControllerUtils {
 
     public static EmployerReportDto convertToDto(EmployerReport er) {
         if (er == null) {
-            throw new IllegalArgumentException("Employer Report does not exist!");
+            throw new IllegalArgumentException(ERROR_PREFIX + "Employer Report does not exist!");
         }
 
         EmployerReportDto employerReportDto =
@@ -792,7 +781,8 @@ public class ControllerUtils {
         if (employerReports != null && employerReports.size() > 0) {
             for (EmployerReport er : employerReports) {
                 if (er == null) {
-                    throw new IllegalArgumentException("Employer Report does not exist!");
+                    throw new IllegalArgumentException(
+                            ERROR_PREFIX + "Employer Report does not exist!");
                 }
                 employerReportDtos.add(convertToDto(er));
             }
@@ -803,7 +793,8 @@ public class ControllerUtils {
 
     public static StudentReportSectionDto convertToDto(StudentReportSection rs) {
         if (rs == null) {
-            throw new IllegalArgumentException("Student report section does not exist!");
+            throw new IllegalArgumentException(
+                    ERROR_PREFIX + "Student report section does not exist!");
         }
         return new StudentReportSectionDto(
                 rs.getId(),
@@ -818,7 +809,8 @@ public class ControllerUtils {
 
         for (StudentReportSection rs : reportSections) {
             if (rs == null) {
-                throw new IllegalArgumentException("Student report section does not exist!");
+                throw new IllegalArgumentException(
+                        ERROR_PREFIX + "Student report section does not exist!");
             }
             reportSectionDtos.add(convertToDto(rs));
         }
@@ -827,7 +819,8 @@ public class ControllerUtils {
 
     public static EmployerReportSectionDto convertToDto(EmployerReportSection rs) {
         if (rs == null) {
-            throw new IllegalArgumentException("Employer report section does not exist!");
+            throw new IllegalArgumentException(
+                    ERROR_PREFIX + "Employer report section does not exist!");
         }
         return new EmployerReportSectionDto(
                 rs.getId(),
@@ -843,7 +836,8 @@ public class ControllerUtils {
 
         for (EmployerReportSection rs : reportSections) {
             if (rs == null) {
-                throw new IllegalArgumentException("Employer report section does not exist!");
+                throw new IllegalArgumentException(
+                        ERROR_PREFIX + "Employer report section does not exist!");
             }
             reportSectionDtos.add(convertToDto(rs));
         }
@@ -852,7 +846,7 @@ public class ControllerUtils {
 
     public static NotificationDto convertToDto(Notification n) {
         if (n == null) {
-            throw new IllegalArgumentException("Notification does not exist!");
+            throw new IllegalArgumentException(ERROR_PREFIX + "Notification does not exist!");
         }
 
         NotificationDto notificationDto =
@@ -900,7 +894,7 @@ public class ControllerUtils {
 
         for (Notification n : notifs) {
             if (n == null) {
-                throw new IllegalArgumentException("Notification does not exist!");
+                throw new IllegalArgumentException(ERROR_PREFIX + "Notification does not exist!");
             }
             notifDtos.add(convertToDto(n));
         }
@@ -912,7 +906,7 @@ public class ControllerUtils {
 
         for (Notification n : notifs) {
             if (n == null) {
-                throw new IllegalArgumentException("Notification does not exist!");
+                throw new IllegalArgumentException(ERROR_PREFIX + "Notification does not exist!");
             }
             notifDtos.add(convertToDto(n));
         }
@@ -921,7 +915,7 @@ public class ControllerUtils {
 
     public static StudentDto convertToDto(Student s) {
         if (s == null) {
-            throw new IllegalArgumentException("Student does not exist!");
+            throw new IllegalArgumentException(ERROR_PREFIX + "Student does not exist!");
         }
 
         StudentDto studentDto =
@@ -1022,7 +1016,7 @@ public class ControllerUtils {
 
         for (Student s : students) {
             if (s == null) {
-                throw new IllegalArgumentException("Student does not exist!");
+                throw new IllegalArgumentException(ERROR_PREFIX + "Student does not exist!");
             }
             studentDtos.add(convertToDto(s));
         }
@@ -1031,7 +1025,7 @@ public class ControllerUtils {
 
     public static StudentReportDto convertToDto(StudentReport sr) {
         if (sr == null) {
-            throw new IllegalArgumentException("Student Report does not exist!");
+            throw new IllegalArgumentException(ERROR_PREFIX + "Student Report does not exist!");
         }
 
         StudentReportDto studentReportDto =
@@ -1068,7 +1062,6 @@ public class ControllerUtils {
                         null); // null notifications, look up student by id to get all notifications
 
         coopDto.setStudent(studentDto);
-
         studentReportDto.setCoop(coopDto);
 
         // create report section dtos
@@ -1097,7 +1090,7 @@ public class ControllerUtils {
 
         for (StudentReport sr : studentReports) {
             if (sr == null) {
-                throw new IllegalArgumentException("Student Report does not exist!");
+                throw new IllegalArgumentException(ERROR_PREFIX + "Student Report does not exist!");
             }
             studentReportDtos.add(convertToDto(sr));
         }

--- a/Backend/src/main/java/ca/mcgill/cooperator/service/AdminService.java
+++ b/Backend/src/main/java/ca/mcgill/cooperator/service/AdminService.java
@@ -11,7 +11,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 @Service
-public class AdminService {
+public class AdminService extends BaseService {
 
     @Autowired AdminRepository adminRepository;
     @Autowired NotificationRepository notificationRepository;
@@ -39,7 +39,7 @@ public class AdminService {
             error.append("Admin email must be a valid email!");
         }
         if (error.length() > 0) {
-            throw new IllegalArgumentException(error.toString().trim());
+            throw new IllegalArgumentException(ERROR_PREFIX + error.toString().trim());
         }
 
         Admin a = new Admin();
@@ -61,7 +61,8 @@ public class AdminService {
     public Admin getAdmin(int id) {
         Admin a = adminRepository.findById(id).orElse(null);
         if (a == null) {
-            throw new IllegalArgumentException("Admin with ID " + id + " does not exist!");
+            throw new IllegalArgumentException(
+                    ERROR_PREFIX + "Admin with ID " + id + " does not exist!");
         }
 
         return a;
@@ -78,7 +79,7 @@ public class AdminService {
         Admin a = adminRepository.findByEmail(email.trim());
         if (a == null) {
             throw new IllegalArgumentException(
-                    "Admin with email " + email.trim() + " does not exist!");
+                    ERROR_PREFIX + "Admin with email " + email.trim() + " does not exist!");
         }
 
         return a;
@@ -127,7 +128,7 @@ public class AdminService {
             error.append("Admin email must be a valid email!");
         }
         if (error.length() > 0) {
-            throw new IllegalArgumentException(error.toString().trim());
+            throw new IllegalArgumentException(ERROR_PREFIX + error.toString().trim());
         }
         // set fields if they're not null
 
@@ -157,7 +158,7 @@ public class AdminService {
     @Transactional
     public Admin deleteAdmin(Admin a) {
         if (a == null) {
-            throw new IllegalArgumentException("Admin to delete cannot be null!");
+            throw new IllegalArgumentException(ERROR_PREFIX + "Admin to delete cannot be null!");
         }
         adminRepository.delete(a);
 

--- a/Backend/src/main/java/ca/mcgill/cooperator/service/BaseService.java
+++ b/Backend/src/main/java/ca/mcgill/cooperator/service/BaseService.java
@@ -1,0 +1,6 @@
+package ca.mcgill.cooperator.service;
+
+public class BaseService {
+
+    static final String ERROR_PREFIX = "ERROR [Service]: ";
+}

--- a/Backend/src/main/java/ca/mcgill/cooperator/service/CompanyService.java
+++ b/Backend/src/main/java/ca/mcgill/cooperator/service/CompanyService.java
@@ -10,10 +10,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 @Service
-public class CompanyService {
+public class CompanyService extends BaseService {
 
     @Autowired CompanyRepository companyRepository;
-
     @Autowired EmployerContactRepository employerContactRepository;
 
     /**
@@ -54,7 +53,7 @@ public class CompanyService {
             error.append("Company with this name and location already exists!");
         }
         if (error.length() > 0) {
-            throw new IllegalArgumentException(error.toString().trim());
+            throw new IllegalArgumentException(ERROR_PREFIX + error.toString().trim());
         }
 
         Company c = new Company();
@@ -78,7 +77,8 @@ public class CompanyService {
     public Company getCompany(int id) {
         Company c = companyRepository.findById(id).orElse(null);
         if (c == null) {
-            throw new IllegalArgumentException("Company with ID " + id + " does not exist!");
+            throw new IllegalArgumentException(
+                    ERROR_PREFIX + "Company with ID " + id + " does not exist!");
         }
 
         return c;
@@ -101,7 +101,8 @@ public class CompanyService {
         if (c == null) {
             String location = city.trim() + ", " + region.trim() + " " + country.trim();
             throw new IllegalArgumentException(
-                    "Company with name "
+                    ERROR_PREFIX
+                            + "Company with name "
                             + name.trim()
                             + " and location "
                             + location
@@ -123,7 +124,7 @@ public class CompanyService {
 
         if (companies == null || companies.isEmpty()) {
             throw new IllegalArgumentException(
-                    "No offices for company with name " + name.trim() + "!");
+                    ERROR_PREFIX + "No offices for company with name " + name.trim() + "!");
         }
 
         return companies;
@@ -172,7 +173,7 @@ public class CompanyService {
             error.append("Company country cannot be empty! ");
         }
         if (error.length() > 0) {
-            throw new IllegalArgumentException(error.toString().trim());
+            throw new IllegalArgumentException(ERROR_PREFIX + error.toString().trim());
         }
 
         if (name == null) {
@@ -189,8 +190,8 @@ public class CompanyService {
         }
 
         if (companyExists(name, city, region, country)) {
-            String errorMessage = "Company with this name and location already exists!";
-            throw new IllegalArgumentException(errorMessage);
+            throw new IllegalArgumentException(
+                    ERROR_PREFIX + "Company with this name and location already exists!");
         }
 
         c.setName(name.trim());
@@ -214,7 +215,7 @@ public class CompanyService {
     @Transactional
     public Company deleteCompany(Company c) {
         if (c == null) {
-            throw new IllegalArgumentException("Company to delete cannot be null!");
+            throw new IllegalArgumentException(ERROR_PREFIX + "Company to delete cannot be null!");
         }
         companyRepository.delete(c);
 

--- a/Backend/src/main/java/ca/mcgill/cooperator/service/CoopDetailsService.java
+++ b/Backend/src/main/java/ca/mcgill/cooperator/service/CoopDetailsService.java
@@ -13,7 +13,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
-public class CoopDetailsService {
+public class CoopDetailsService extends BaseService {
+
     @Autowired CoopDetailsRepository coopDetailsRepository;
     @Autowired EmployerContactRepository employerContactRepository;
     @Autowired CoopRepository coopRepository;
@@ -44,7 +45,7 @@ public class CoopDetailsService {
             error.append("Co-op cannot be null!");
         }
         if (error.length() > 0) {
-            throw new IllegalArgumentException(error.toString().trim());
+            throw new IllegalArgumentException(ERROR_PREFIX + error.toString().trim());
         }
 
         CoopDetails cd = new CoopDetails();
@@ -66,7 +67,8 @@ public class CoopDetailsService {
     public CoopDetails getCoopDetails(int id) {
         CoopDetails cd = coopDetailsRepository.findById(id).orElse(null);
         if (cd == null) {
-            throw new IllegalArgumentException("Co-op Details with ID " + id + " does not exist!");
+            throw new IllegalArgumentException(
+                    ERROR_PREFIX + "Co-op Details with ID " + id + " does not exist!");
         }
 
         return cd;
@@ -91,7 +93,8 @@ public class CoopDetailsService {
     @Transactional
     public CoopDetails deleteCoopDetails(CoopDetails cd) {
         if (cd == null) {
-            throw new IllegalArgumentException("Co-op Details to delete cannot be null!");
+            throw new IllegalArgumentException(
+                    ERROR_PREFIX + "Co-op Details to delete cannot be null!");
         }
         Coop c = cd.getCoop();
         c.setCoopDetails(null);
@@ -125,7 +128,7 @@ public class CoopDetailsService {
             error.append("Co-op Details to update cannot be null!");
         }
         if (error.length() > 0) {
-            throw new IllegalArgumentException(error.toString().trim());
+            throw new IllegalArgumentException(ERROR_PREFIX + error.toString().trim());
         }
 
         if (payPerHour >= 0) {

--- a/Backend/src/main/java/ca/mcgill/cooperator/service/CoopService.java
+++ b/Backend/src/main/java/ca/mcgill/cooperator/service/CoopService.java
@@ -23,7 +23,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
-public class CoopService {
+public class CoopService extends BaseService {
 
     @Autowired CoopRepository coopRepository;
     @Autowired StudentRepository studentRepository;
@@ -54,7 +54,7 @@ public class CoopService {
             error.append("Student cannot be null.");
         }
         if (error.length() > 0) {
-            throw new IllegalArgumentException(error.toString().trim());
+            throw new IllegalArgumentException(ERROR_PREFIX + error.toString().trim());
         }
 
         Coop c = new Coop();
@@ -71,7 +71,8 @@ public class CoopService {
     public Coop getCoopById(int id) {
         Coop c = coopRepository.findById(id).orElse(null);
         if (c == null) {
-            throw new IllegalArgumentException("Co-op with ID " + id + " does not exist!");
+            throw new IllegalArgumentException(
+                    ERROR_PREFIX + "Co-op with ID " + id + " does not exist!");
         }
 
         return c;
@@ -101,7 +102,7 @@ public class CoopService {
             error.append("Co-op to update cannot be null! ");
         }
         if (error.length() > 0) {
-            throw new IllegalArgumentException(error.toString().trim());
+            throw new IllegalArgumentException(ERROR_PREFIX + error.toString().trim());
         }
 
         if (status != null) {
@@ -129,7 +130,7 @@ public class CoopService {
     @Transactional
     public List<Coop> getCoopsByStatus(CoopStatus status) {
         if (status == null) {
-            throw new IllegalArgumentException("Status cannot be null.");
+            throw new IllegalArgumentException(ERROR_PREFIX + "Status cannot be null.");
         }
         List<Coop> coops = coopRepository.findByStatus(status);
         return coops;
@@ -138,7 +139,7 @@ public class CoopService {
     @Transactional
     public Coop deleteCoop(Coop c) {
         if (c == null) {
-            throw new IllegalArgumentException("Co-op to delete cannot be null!");
+            throw new IllegalArgumentException(ERROR_PREFIX + "Co-op to delete cannot be null!");
         }
 
         Student s = c.getStudent();
@@ -157,16 +158,18 @@ public class CoopService {
         if (coopDetails != null) {
             coopDetails.setCoop(null);
             coopDetailsRepository.save(coopDetails);
+
             c.setCoopDetails(null);
             coopRepository.save(c);
+
             EmployerContact ec = coopDetails.getEmployerContact();
             Set<CoopDetails> details = ec.getCoopDetails();
             details.remove(coopDetails);
             ec.setCoopDetails(details);
+
             employerContactRepository.save(ec);
             coopDetailsRepository.delete(coopDetails);
         }
-
         coopRepository.delete(c);
 
         return c;

--- a/Backend/src/main/java/ca/mcgill/cooperator/service/CourseOfferingService.java
+++ b/Backend/src/main/java/ca/mcgill/cooperator/service/CourseOfferingService.java
@@ -13,7 +13,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
-public class CourseOfferingService {
+public class CourseOfferingService extends BaseService {
     @Autowired CourseOfferingRepository courseOfferingRepository;
     @Autowired CourseRepository courseRepository;
 
@@ -38,7 +38,7 @@ public class CourseOfferingService {
             error.append("Course cannot be null!");
         }
         if (error.length() > 0) {
-            throw new IllegalArgumentException(error.toString().trim());
+            throw new IllegalArgumentException(ERROR_PREFIX + error.toString().trim());
         }
 
         CourseOffering co = new CourseOffering();
@@ -58,7 +58,7 @@ public class CourseOfferingService {
             error.append("Course Offering to update cannot be null!");
         }
         if (error.length() > 0) {
-            throw new IllegalArgumentException(error.toString().trim());
+            throw new IllegalArgumentException(ERROR_PREFIX + error.toString().trim());
         }
 
         if (year > 0) {
@@ -79,7 +79,7 @@ public class CourseOfferingService {
         CourseOffering c = courseOfferingRepository.findById(id).orElse(null);
         if (c == null) {
             throw new IllegalArgumentException(
-                    "Course Offering with ID " + id + " does not exist!");
+                    ERROR_PREFIX + "Course Offering with ID " + id + " does not exist!");
         }
         return c;
     }
@@ -89,7 +89,10 @@ public class CourseOfferingService {
         List<CourseOffering> co = courseOfferingRepository.findByCourse(c);
         if (co == null) {
             throw new IllegalArgumentException(
-                    "There are no course offerings for the course " + c.getName() + "!");
+                    ERROR_PREFIX
+                            + "There are no course offerings for the course "
+                            + c.getName()
+                            + "!");
         }
         return co;
     }
@@ -105,19 +108,25 @@ public class CourseOfferingService {
     public List<CourseOffering> getAllCourseOfferings() {
         List<CourseOffering> co = ServiceUtils.toList(courseOfferingRepository.findAll());
         if (co == null) {
-            throw new IllegalArgumentException("There are no course offerings!");
+            throw new IllegalArgumentException(ERROR_PREFIX + "There are no course offerings!");
         }
         return co;
     }
 
     @Transactional
     public CourseOffering deleteCourseOffering(CourseOffering co) {
+        if (co == null) {
+            throw new IllegalArgumentException(
+                    ERROR_PREFIX + "Course offering to delete cannot be null!");
+        }
         courseOfferingRepository.delete(co);
+
         Course c = co.getCourse();
         List<CourseOffering> cos = c.getCourseOfferings();
         cos.remove(co);
         c.setCourseOfferings(cos);
         courseRepository.save(c);
+
         return co;
     }
 }

--- a/Backend/src/main/java/ca/mcgill/cooperator/service/CourseService.java
+++ b/Backend/src/main/java/ca/mcgill/cooperator/service/CourseService.java
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
-public class CourseService {
+public class CourseService extends BaseService {
     @Autowired CourseRepository courseRepository;
 
     /**
@@ -26,7 +26,7 @@ public class CourseService {
             error.append("Course name cannot be empty!");
         }
         if (error.length() > 0) {
-            throw new IllegalArgumentException(error.toString().trim());
+            throw new IllegalArgumentException(ERROR_PREFIX + error.toString().trim());
         }
 
         Course c = new Course();
@@ -46,7 +46,7 @@ public class CourseService {
             error.append("Course name cannot be empty!");
         }
         if (error.length() > 0) {
-            throw new IllegalArgumentException(error.toString().trim());
+            throw new IllegalArgumentException(ERROR_PREFIX + error.toString().trim());
         }
 
         if (offerings != null) {
@@ -63,7 +63,8 @@ public class CourseService {
     public Course getCourseByName(String name) {
         Course c = courseRepository.findByName(name.trim());
         if (c == null) {
-            throw new IllegalArgumentException("Course with name " + name + " does not exist!");
+            throw new IllegalArgumentException(
+                    ERROR_PREFIX + "Course with name " + name + " does not exist!");
         }
         return c;
     }
@@ -72,7 +73,8 @@ public class CourseService {
     public Course getCourseById(int id) {
         Course c = courseRepository.findById(id).orElse(null);
         if (c == null) {
-            throw new IllegalArgumentException("Course with ID " + id + " does not exist!");
+            throw new IllegalArgumentException(
+                    ERROR_PREFIX + "Course with ID " + id + " does not exist!");
         }
         return c;
     }
@@ -85,7 +87,7 @@ public class CourseService {
     @Transactional
     public Course deleteCourse(Course c) {
         if (c == null) {
-            throw new IllegalArgumentException("Course to delete cannot be null!");
+            throw new IllegalArgumentException(ERROR_PREFIX + "Course to delete cannot be null!");
         }
         courseRepository.delete(c);
         return c;

--- a/Backend/src/main/java/ca/mcgill/cooperator/service/EmployerContactService.java
+++ b/Backend/src/main/java/ca/mcgill/cooperator/service/EmployerContactService.java
@@ -16,7 +16,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 @Service
-public class EmployerContactService {
+public class EmployerContactService extends BaseService {
 
     @Autowired EmployerContactRepository employerContactRepository;
     @Autowired CompanyRepository companyRepository;
@@ -57,7 +57,7 @@ public class EmployerContactService {
             error.append("Employer Contact company cannot be empty!");
         }
         if (error.length() > 0) {
-            throw new IllegalArgumentException(error.toString().trim());
+            throw new IllegalArgumentException(ERROR_PREFIX + error.toString().trim());
         }
 
         EmployerContact ec = new EmployerContact();
@@ -83,7 +83,7 @@ public class EmployerContactService {
         EmployerContact ec = employerContactRepository.findById(id).orElse(null);
         if (ec == null) {
             throw new IllegalArgumentException(
-                    "Employer Contact with ID " + id + " does not exist!");
+                    ERROR_PREFIX + "Employer Contact with ID " + id + " does not exist!");
         }
 
         return ec;
@@ -100,7 +100,10 @@ public class EmployerContactService {
         EmployerContact ec = employerContactRepository.findByEmail(email.trim());
         if (ec == null) {
             throw new IllegalArgumentException(
-                    "Employer Contact with email " + email.trim() + " does not exist!");
+                    ERROR_PREFIX
+                            + "Employer Contact with email "
+                            + email.trim()
+                            + " does not exist!");
         }
 
         return ec;
@@ -161,7 +164,7 @@ public class EmployerContactService {
             error.append("Employer Contact phone number must be a valid number! ");
         }
         if (error.length() > 0) {
-            throw new IllegalArgumentException(error.toString().trim());
+            throw new IllegalArgumentException(ERROR_PREFIX + error.toString().trim());
         }
 
         if (firstName != null) {
@@ -198,7 +201,8 @@ public class EmployerContactService {
     @Transactional
     public EmployerContact deleteEmployerContact(EmployerContact ec) {
         if (ec == null) {
-            throw new IllegalArgumentException("Employer Contact to delete cannot be null!");
+            throw new IllegalArgumentException(
+                    ERROR_PREFIX + "Employer Contact to delete cannot be null!");
         }
 
         Company c = ec.getCompany();

--- a/Backend/src/main/java/ca/mcgill/cooperator/service/EmployerReportSectionService.java
+++ b/Backend/src/main/java/ca/mcgill/cooperator/service/EmployerReportSectionService.java
@@ -13,7 +13,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
-public class EmployerReportSectionService {
+public class EmployerReportSectionService extends BaseService {
 
     @Autowired EmployerReportSectionRepository employerReportSectionRepository;
     @Autowired EmployerReportRepository employerReportRepository;
@@ -43,7 +43,7 @@ public class EmployerReportSectionService {
             error.append("Employer report cannot be null!");
         }
         if (error.length() > 0) {
-            throw new IllegalArgumentException(error.toString().trim());
+            throw new IllegalArgumentException(ERROR_PREFIX + error.toString().trim());
         }
 
         EmployerReportSection rs = new EmployerReportSection();
@@ -65,7 +65,7 @@ public class EmployerReportSectionService {
         EmployerReportSection rs = employerReportSectionRepository.findById(id).orElse(null);
         if (rs == null) {
             throw new IllegalArgumentException(
-                    "Employer report Section with ID " + id + " does not exist!");
+                    ERROR_PREFIX + "Employer report Section with ID " + id + " does not exist!");
         }
 
         return rs;
@@ -104,7 +104,7 @@ public class EmployerReportSectionService {
             error.append("Response cannot be empty!");
         }
         if (error.length() > 0) {
-            throw new IllegalArgumentException(error.toString().trim());
+            throw new IllegalArgumentException(ERROR_PREFIX + error.toString().trim());
         }
 
         if (response != null) {
@@ -129,7 +129,8 @@ public class EmployerReportSectionService {
     @Transactional
     public EmployerReportSection deleteReportSection(EmployerReportSection rs) {
         if (rs == null) {
-            throw new IllegalArgumentException("Employer report section to delete cannot be null!");
+            throw new IllegalArgumentException(
+                    ERROR_PREFIX + "Employer report section to delete cannot be null!");
         }
 
         // first delete from parents

--- a/Backend/src/main/java/ca/mcgill/cooperator/service/EmployerReportService.java
+++ b/Backend/src/main/java/ca/mcgill/cooperator/service/EmployerReportService.java
@@ -19,7 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 @Service
-public class EmployerReportService {
+public class EmployerReportService extends BaseService {
 
     @Autowired EmployerContactRepository employerContactRepository;
     @Autowired EmployerReportRepository employerReportRepository;
@@ -53,7 +53,7 @@ public class EmployerReportService {
             error.append("File title cannot be empty! ");
         }
         if (error.length() > 0) {
-            throw new IllegalArgumentException(error.toString().trim());
+            throw new IllegalArgumentException(ERROR_PREFIX + error.toString().trim());
         }
 
         EmployerReport er = new EmployerReport();
@@ -84,7 +84,7 @@ public class EmployerReportService {
         EmployerReport er = employerReportRepository.findById(id).orElse(null);
         if (er == null) {
             throw new IllegalArgumentException(
-                    "Employer Report with ID " + id + " does not exist!");
+                    ERROR_PREFIX + "Employer Report with ID " + id + " does not exist!");
         }
 
         return er;
@@ -127,7 +127,7 @@ public class EmployerReportService {
             error.append("File title cannot be empty! ");
         }
         if (error.length() > 0) {
-            throw new IllegalArgumentException(error.toString().trim());
+            throw new IllegalArgumentException(ERROR_PREFIX + error.toString().trim());
         }
 
         // set all values in employer report if they're not null
@@ -175,7 +175,8 @@ public class EmployerReportService {
     @Transactional
     public EmployerReport deleteEmployerReport(EmployerReport er) {
         if (er == null) {
-            throw new IllegalArgumentException("Employer Report to delete cannot be null!");
+            throw new IllegalArgumentException(
+                    ERROR_PREFIX + "Employer Report to delete cannot be null!");
         }
 
         // first delete from all parents

--- a/Backend/src/main/java/ca/mcgill/cooperator/service/NotificationService.java
+++ b/Backend/src/main/java/ca/mcgill/cooperator/service/NotificationService.java
@@ -14,7 +14,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
-public class NotificationService {
+public class NotificationService extends BaseService {
 
     @Autowired NotificationRepository notificationRepository;
     @Autowired StudentRepository studentRepository;
@@ -46,7 +46,7 @@ public class NotificationService {
             error.append("Notification must have an Admin sender!");
         }
         if (error.length() > 0) {
-            throw new IllegalArgumentException(error.toString().trim());
+            throw new IllegalArgumentException(ERROR_PREFIX + error.toString().trim());
         }
 
         Notification n = new Notification();
@@ -70,7 +70,8 @@ public class NotificationService {
     public Notification getNotification(int id) {
         Notification n = notificationRepository.findById(id).orElse(null);
         if (n == null) {
-            throw new IllegalArgumentException("Notification with ID " + id + " does not exist!");
+            throw new IllegalArgumentException(
+                    ERROR_PREFIX + "Notification with ID " + id + " does not exist!");
         }
 
         return n;
@@ -130,7 +131,7 @@ public class NotificationService {
     public Notification markAsRead(Notification n) {
         if (n != null) n.setSeen(true);
         else {
-            throw new IllegalArgumentException("Notification cannot be null!");
+            throw new IllegalArgumentException(ERROR_PREFIX + "Notification cannot be null!");
         }
         notificationRepository.save(n);
         return n;
@@ -166,7 +167,7 @@ public class NotificationService {
             error.append("Notification must have an Admin sender!");
         }
         if (error.length() > 0) {
-            throw new IllegalArgumentException(error.toString().trim());
+            throw new IllegalArgumentException(ERROR_PREFIX + error.toString().trim());
         }
 
         if (title != null) {
@@ -194,7 +195,8 @@ public class NotificationService {
     @Transactional
     public Notification deleteNotification(Notification n) {
         if (n == null) {
-            throw new IllegalArgumentException("Notification to delete cannot be null!");
+            throw new IllegalArgumentException(
+                    ERROR_PREFIX + "Notification to delete cannot be null!");
         }
 
         Student s = n.getStudent();

--- a/Backend/src/main/java/ca/mcgill/cooperator/service/ReportConfigService.java
+++ b/Backend/src/main/java/ca/mcgill/cooperator/service/ReportConfigService.java
@@ -12,7 +12,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 @Service
-public class ReportConfigService {
+public class ReportConfigService extends BaseService {
 
     @Autowired ReportConfigRepository reportConfigRepository;
 
@@ -36,7 +36,7 @@ public class ReportConfigService {
             error.append("Report type cannot be empty!");
         }
         if (error.length() > 0) {
-            throw new IllegalArgumentException("ERROR [Service]: " + error.toString().trim());
+            throw new IllegalArgumentException(ERROR_PREFIX + error.toString().trim());
         }
 
         ReportConfig reportConfig = new ReportConfig();
@@ -60,7 +60,7 @@ public class ReportConfigService {
         ReportConfig reportConfig = reportConfigRepository.findById(id).orElse(null);
         if (reportConfig == null) {
             throw new IllegalArgumentException(
-                    "ERROR [Service]: Report config with ID " + id + " does not exist!");
+                    ERROR_PREFIX + "Report config with ID " + id + " does not exist!");
         }
 
         return reportConfig;
@@ -77,7 +77,7 @@ public class ReportConfigService {
         ReportConfig reportConfig = reportConfigRepository.findByType(type);
         if (reportConfig == null) {
             throw new IllegalArgumentException(
-                    "ERROR [Service]: Report config with type " + type + " does not exist!");
+                    ERROR_PREFIX + "Report config with type " + type + " does not exist!");
         }
 
         return reportConfig;
@@ -138,7 +138,7 @@ public class ReportConfigService {
             error.append("Report type cannot be empty!");
         }
         if (error.length() > 0) {
-            throw new IllegalArgumentException("ERROR [Service]: " + error.toString().trim());
+            throw new IllegalArgumentException(ERROR_PREFIX + error.toString().trim());
         }
 
         if (requiresFile != null) {
@@ -170,7 +170,7 @@ public class ReportConfigService {
     public ReportConfig deleteReportConfig(ReportConfig reportConfig) {
         if (reportConfig == null) {
             throw new IllegalArgumentException(
-                    "ERROR [Service]: Report config to delete cannot be null!");
+                    ERROR_PREFIX + "Report config to delete cannot be null!");
         }
 
         reportConfigRepository.delete(reportConfig);

--- a/Backend/src/main/java/ca/mcgill/cooperator/service/ReportSectionConfigService.java
+++ b/Backend/src/main/java/ca/mcgill/cooperator/service/ReportSectionConfigService.java
@@ -14,7 +14,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 @Service
-public class ReportSectionConfigService {
+public class ReportSectionConfigService extends BaseService {
 
     @Autowired ReportConfigRepository reportConfigRepository;
     @Autowired ReportSectionConfigRepository reportSectionConfigRepository;
@@ -41,7 +41,7 @@ public class ReportSectionConfigService {
             error.append("Report config cannot be null!");
         }
         if (error.length() > 0) {
-            throw new IllegalArgumentException(error.toString().trim());
+            throw new IllegalArgumentException(ERROR_PREFIX + error.toString().trim());
         }
 
         ReportSectionConfig rsConfig = new ReportSectionConfig();
@@ -65,7 +65,7 @@ public class ReportSectionConfigService {
         ReportSectionConfig rsConfig = reportSectionConfigRepository.findById(id).orElse(null);
         if (rsConfig == null) {
             throw new IllegalArgumentException(
-                    "Report section config with ID " + id + " does not exist!");
+                    ERROR_PREFIX + "Report section config with ID " + id + " does not exist!");
         }
 
         return rsConfig;
@@ -98,7 +98,7 @@ public class ReportSectionConfigService {
             error.append("Section prompt cannot be empty! ");
         }
         if (error.length() > 0) {
-            throw new IllegalArgumentException(error.toString().trim());
+            throw new IllegalArgumentException(ERROR_PREFIX + error.toString().trim());
         }
 
         if (sectionPrompt != null) {
@@ -129,7 +129,8 @@ public class ReportSectionConfigService {
     @Transactional
     public ReportSectionConfig deleteReportSectionConfig(ReportSectionConfig rsConfig) {
         if (rsConfig == null) {
-            throw new IllegalArgumentException("Report section config to delete cannot be null!");
+            throw new IllegalArgumentException(
+                    ERROR_PREFIX + "Report section config to delete cannot be null!");
         }
 
         // first delete from parent ReportConfig

--- a/Backend/src/main/java/ca/mcgill/cooperator/service/StudentReportSectionService.java
+++ b/Backend/src/main/java/ca/mcgill/cooperator/service/StudentReportSectionService.java
@@ -13,7 +13,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
-public class StudentReportSectionService {
+public class StudentReportSectionService extends BaseService {
 
     @Autowired ReportSectionConfigRepository reportSectionConfigRepository;
     @Autowired StudentReportSectionRepository studentReportSectionRepository;
@@ -41,7 +41,7 @@ public class StudentReportSectionService {
             error.append("Student report cannot be null!");
         }
         if (error.length() > 0) {
-            throw new IllegalArgumentException(error.toString().trim());
+            throw new IllegalArgumentException(ERROR_PREFIX + error.toString().trim());
         }
 
         StudentReportSection rs = new StudentReportSection();
@@ -63,7 +63,7 @@ public class StudentReportSectionService {
         StudentReportSection rs = studentReportSectionRepository.findById(id).orElse(null);
         if (rs == null) {
             throw new IllegalArgumentException(
-                    "Student report section with ID " + id + " does not exist!");
+                    ERROR_PREFIX + "Student report section with ID " + id + " does not exist!");
         }
 
         return rs;
@@ -102,7 +102,7 @@ public class StudentReportSectionService {
             error.append("Response cannot be empty!");
         }
         if (error.length() > 0) {
-            throw new IllegalArgumentException(error.toString().trim());
+            throw new IllegalArgumentException(ERROR_PREFIX + error.toString().trim());
         }
 
         if (response != null) {
@@ -127,7 +127,8 @@ public class StudentReportSectionService {
     @Transactional
     public StudentReportSection deleteReportSection(StudentReportSection rs) {
         if (rs == null) {
-            throw new IllegalArgumentException("Student report section to delete cannot be null!");
+            throw new IllegalArgumentException(
+                    ERROR_PREFIX + "Student report section to delete cannot be null!");
         }
 
         // first delete from parents

--- a/Backend/src/main/java/ca/mcgill/cooperator/service/StudentReportService.java
+++ b/Backend/src/main/java/ca/mcgill/cooperator/service/StudentReportService.java
@@ -17,7 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 @Service
-public class StudentReportService {
+public class StudentReportService extends BaseService {
 
     @Autowired CoopRepository coopRepository;
     @Autowired StudentReportRepository studentReportRepository;
@@ -46,7 +46,7 @@ public class StudentReportService {
             error.append("File title cannot be empty! ");
         }
         if (error.length() > 0) {
-            throw new IllegalArgumentException(error.toString().trim());
+            throw new IllegalArgumentException(ERROR_PREFIX + error.toString().trim());
         }
 
         StudentReport sr = new StudentReport();
@@ -76,7 +76,8 @@ public class StudentReportService {
     public StudentReport getStudentReport(int id) {
         StudentReport sr = studentReportRepository.findById(id).orElse(null);
         if (sr == null) {
-            throw new IllegalArgumentException("Student Report with ID " + id + " does not exist!");
+            throw new IllegalArgumentException(
+                    ERROR_PREFIX + "Student Report with ID " + id + " does not exist!");
         }
 
         return sr;
@@ -116,7 +117,7 @@ public class StudentReportService {
             error.append("File title cannot be empty! ");
         }
         if (error.length() > 0) {
-            throw new IllegalArgumentException(error.toString().trim());
+            throw new IllegalArgumentException(ERROR_PREFIX + error.toString().trim());
         }
 
         if (status != null) {
@@ -163,7 +164,8 @@ public class StudentReportService {
     @Transactional
     public StudentReport deleteStudentReport(StudentReport sr) {
         if (sr == null) {
-            throw new IllegalArgumentException("Student Report to delete cannot be null!");
+            throw new IllegalArgumentException(
+                    ERROR_PREFIX + "Student Report to delete cannot be null!");
         }
 
         // first delete from all parents

--- a/Backend/src/main/java/ca/mcgill/cooperator/service/StudentService.java
+++ b/Backend/src/main/java/ca/mcgill/cooperator/service/StudentService.java
@@ -14,7 +14,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
-public class StudentService {
+public class StudentService extends BaseService {
     @Autowired StudentRepository studentRepository;
     @Autowired CoopRepository coopRepository;
     @Autowired NotificationRepository notificationRepository;
@@ -47,7 +47,7 @@ public class StudentService {
             error.append("Student ID cannot be null or invalid.");
         }
         if (error.length() > 0) {
-            throw new IllegalArgumentException(error.toString().trim());
+            throw new IllegalArgumentException(ERROR_PREFIX + error.toString().trim());
         }
 
         Student s = new Student();
@@ -75,7 +75,8 @@ public class StudentService {
         }
         List<Student> s = studentRepository.findByFirstNameAndLastName(firstName, lastName);
         if (s == null) {
-            throw new IllegalArgumentException("No students exist with that first and last name.");
+            throw new IllegalArgumentException(
+                    ERROR_PREFIX + "No students exist with that first and last name.");
         }
         return s;
     }
@@ -83,12 +84,13 @@ public class StudentService {
     @Transactional
     public List<Student> getStudentByFirstName(String firstName) {
         if (firstName == null || firstName.trim().length() == 0) {
-            throw new IllegalArgumentException("FirstName is null or invalid. ");
+            throw new IllegalArgumentException(ERROR_PREFIX + "FirstName is null or invalid. ");
         }
 
         List<Student> s = studentRepository.findByFirstName(firstName);
         if (s == null) {
-            throw new IllegalArgumentException("No students exist with that first name.");
+            throw new IllegalArgumentException(
+                    ERROR_PREFIX + "No students exist with that first name.");
         }
         return s;
     }
@@ -96,12 +98,13 @@ public class StudentService {
     @Transactional
     public List<Student> getStudentByLastName(String lastName) {
         if (lastName == null || lastName.trim().length() == 0) {
-            throw new IllegalArgumentException("FirstName is null or invalid. ");
+            throw new IllegalArgumentException(ERROR_PREFIX + "LastName is null or invalid. ");
         }
 
         List<Student> s = studentRepository.findByLastName(lastName);
         if (s == null) {
-            throw new IllegalArgumentException("No students exist with that first name.");
+            throw new IllegalArgumentException(
+                    ERROR_PREFIX + "No students exist with that last name.");
         }
         return s;
     }
@@ -109,11 +112,11 @@ public class StudentService {
     @Transactional
     public Student getStudentByStudentID(String id) {
         if (id == null || id.trim().length() != 9) {
-            throw new IllegalArgumentException("ID is invalid.");
+            throw new IllegalArgumentException(ERROR_PREFIX + "Student ID is invalid.");
         }
         Student s = studentRepository.findByStudentId(id);
         if (s == null) {
-            throw new IllegalArgumentException("Student does not exist.");
+            throw new IllegalArgumentException(ERROR_PREFIX + "Student does not exist.");
         }
         return s;
     }
@@ -121,11 +124,11 @@ public class StudentService {
     @Transactional
     public Student getStudentByID(Integer id) {
         if (id == null || id < 0) {
-            throw new IllegalArgumentException("ID is invalid.");
+            throw new IllegalArgumentException(ERROR_PREFIX + "ID is invalid.");
         }
         Student s = studentRepository.findById(id).orElse(null);
         if (s == null) {
-            throw new IllegalArgumentException("Student does not exist.");
+            throw new IllegalArgumentException(ERROR_PREFIX + "Student does not exist.");
         }
         return s;
     }
@@ -134,7 +137,8 @@ public class StudentService {
     public Student getStudentById(int id) {
         Student s = studentRepository.findById(id).orElse(null);
         if (s == null) {
-            throw new IllegalArgumentException("Student with ID " + id + " does not exist.");
+            throw new IllegalArgumentException(
+                    ERROR_PREFIX + "Student with ID " + id + " does not exist.");
         }
 
         return s;
@@ -174,7 +178,7 @@ public class StudentService {
             error.append("Student ID is invalid.");
         }
         if (error.length() > 0) {
-            throw new IllegalArgumentException(error.toString().trim());
+            throw new IllegalArgumentException(ERROR_PREFIX + error.toString().trim());
         }
 
         if (firstName != null) {
@@ -202,7 +206,7 @@ public class StudentService {
     @Transactional
     public Student deleteStudent(Student s) {
         if (s == null) {
-            throw new IllegalArgumentException("Student to delete cannot be null.");
+            throw new IllegalArgumentException(ERROR_PREFIX + "Student to delete cannot be null.");
         }
 
         studentRepository.delete(s);
@@ -212,11 +216,11 @@ public class StudentService {
     @Transactional
     public Student deleteStudentByStudentID(String id) {
         if (id == null || id.trim().length() != 9) {
-            throw new IllegalArgumentException("ID is invalid.");
+            throw new IllegalArgumentException(ERROR_PREFIX + "ID is invalid.");
         }
         Student s = studentRepository.findByStudentId(id);
         if (s == null) {
-            throw new IllegalArgumentException("Student does not exist.");
+            throw new IllegalArgumentException(ERROR_PREFIX + "Student does not exist.");
         }
         studentRepository.delete(s);
         return s;

--- a/Backend/src/test/java/ca/mcgill/cooperator/controller/AdminControllerIT.java
+++ b/Backend/src/test/java/ca/mcgill/cooperator/controller/AdminControllerIT.java
@@ -27,7 +27,7 @@ import org.springframework.test.web.servlet.MvcResult;
 @SpringBootTest
 @AutoConfigureMockMvc
 @ActiveProfiles("test")
-public class AdminControllerIT {
+public class AdminControllerIT extends BaseControllerIT {
 
     @Autowired private MockMvc mvc;
 

--- a/Backend/src/test/java/ca/mcgill/cooperator/controller/BaseControllerIT.java
+++ b/Backend/src/test/java/ca/mcgill/cooperator/controller/BaseControllerIT.java
@@ -30,7 +30,7 @@ import org.springframework.test.web.servlet.MvcResult;
  *
  * @see CoopControllerIT (example)
  */
-public abstract class ControllerIT {
+public abstract class BaseControllerIT {
 
     @Autowired private MockMvc mvc;
 

--- a/Backend/src/test/java/ca/mcgill/cooperator/controller/CompanyControllerIT.java
+++ b/Backend/src/test/java/ca/mcgill/cooperator/controller/CompanyControllerIT.java
@@ -29,7 +29,7 @@ import org.springframework.test.web.servlet.MvcResult;
 @SpringBootTest
 @AutoConfigureMockMvc
 @ActiveProfiles("test")
-public class CompanyControllerIT extends ControllerIT {
+public class CompanyControllerIT extends BaseControllerIT {
     @Autowired private MockMvc mvc;
 
     @Autowired private ObjectMapper objectMapper;

--- a/Backend/src/test/java/ca/mcgill/cooperator/controller/CoopControllerIT.java
+++ b/Backend/src/test/java/ca/mcgill/cooperator/controller/CoopControllerIT.java
@@ -42,7 +42,7 @@ import org.springframework.test.web.servlet.MvcResult;
 @SpringBootTest
 @AutoConfigureMockMvc
 @ActiveProfiles("test")
-public class CoopControllerIT extends ControllerIT {
+public class CoopControllerIT extends BaseControllerIT {
     @Autowired private MockMvc mvc;
 
     @Autowired private ObjectMapper objectMapper;

--- a/Backend/src/test/java/ca/mcgill/cooperator/controller/CoopDetailsControllerIT.java
+++ b/Backend/src/test/java/ca/mcgill/cooperator/controller/CoopDetailsControllerIT.java
@@ -41,7 +41,7 @@ import org.springframework.test.web.servlet.MvcResult;
 @SpringBootTest
 @AutoConfigureMockMvc
 @ActiveProfiles("test")
-public class CoopDetailsControllerIT extends ControllerIT {
+public class CoopDetailsControllerIT extends BaseControllerIT {
     @Autowired private MockMvc mvc;
 
     @Autowired private ObjectMapper objectMapper;

--- a/Backend/src/test/java/ca/mcgill/cooperator/controller/CourseControllerIT.java
+++ b/Backend/src/test/java/ca/mcgill/cooperator/controller/CourseControllerIT.java
@@ -29,7 +29,7 @@ import org.springframework.test.web.servlet.MvcResult;
 @SpringBootTest
 @AutoConfigureMockMvc
 @ActiveProfiles("test")
-public class CourseControllerIT extends ControllerIT {
+public class CourseControllerIT extends BaseControllerIT {
 
     @Autowired private MockMvc mvc;
 

--- a/Backend/src/test/java/ca/mcgill/cooperator/controller/CourseOfferingControllerIT.java
+++ b/Backend/src/test/java/ca/mcgill/cooperator/controller/CourseOfferingControllerIT.java
@@ -30,7 +30,7 @@ import org.springframework.test.web.servlet.MvcResult;
 @SpringBootTest
 @AutoConfigureMockMvc
 @ActiveProfiles("test")
-public class CourseOfferingControllerIT extends ControllerIT {
+public class CourseOfferingControllerIT extends BaseControllerIT {
 
     @Autowired private MockMvc mvc;
 

--- a/Backend/src/test/java/ca/mcgill/cooperator/controller/EmployerContactControllerIT.java
+++ b/Backend/src/test/java/ca/mcgill/cooperator/controller/EmployerContactControllerIT.java
@@ -31,7 +31,7 @@ import org.springframework.test.web.servlet.MvcResult;
 @SpringBootTest
 @AutoConfigureMockMvc
 @ActiveProfiles("test")
-public class EmployerContactControllerIT extends ControllerIT {
+public class EmployerContactControllerIT extends BaseControllerIT {
 
     @Autowired private MockMvc mvc;
 

--- a/Backend/src/test/java/ca/mcgill/cooperator/controller/EmployerReportControllerIT.java
+++ b/Backend/src/test/java/ca/mcgill/cooperator/controller/EmployerReportControllerIT.java
@@ -51,7 +51,7 @@ import org.springframework.web.multipart.MultipartFile;
 @SpringBootTest
 @AutoConfigureMockMvc
 @ActiveProfiles("test")
-public class EmployerReportControllerIT extends ControllerIT {
+public class EmployerReportControllerIT extends BaseControllerIT {
 
     @Autowired private MockMvc mvc;
 

--- a/Backend/src/test/java/ca/mcgill/cooperator/controller/StudentReportControllerIT.java
+++ b/Backend/src/test/java/ca/mcgill/cooperator/controller/StudentReportControllerIT.java
@@ -44,7 +44,7 @@ import org.springframework.web.multipart.MultipartFile;
 @SpringBootTest
 @AutoConfigureMockMvc
 @ActiveProfiles("test")
-public class StudentReportControllerIT extends ControllerIT {
+public class StudentReportControllerIT extends BaseControllerIT {
 
     @Autowired private MockMvc mvc;
 

--- a/Backend/src/test/java/ca/mcgill/cooperator/cucumber/AdminApproveCoopIT.java
+++ b/Backend/src/test/java/ca/mcgill/cooperator/cucumber/AdminApproveCoopIT.java
@@ -6,7 +6,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import ca.mcgill.cooperator.controller.ControllerIT;
+import ca.mcgill.cooperator.controller.BaseControllerIT;
 import ca.mcgill.cooperator.dao.CompanyRepository;
 import ca.mcgill.cooperator.dao.CoopDetailsRepository;
 import ca.mcgill.cooperator.dao.CourseOfferingRepository;
@@ -50,7 +50,7 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.request.RequestPostProcessor;
 import org.springframework.web.multipart.MultipartFile;
 
-public class AdminApproveCoopIT extends ControllerIT {
+public class AdminApproveCoopIT extends BaseControllerIT {
 
     @Autowired private MockMvc mvc;
 

--- a/Backend/src/test/java/ca/mcgill/cooperator/cucumber/StudentGetCoopInfoIT.java
+++ b/Backend/src/test/java/ca/mcgill/cooperator/cucumber/StudentGetCoopInfoIT.java
@@ -4,7 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import ca.mcgill.cooperator.controller.ControllerIT;
+import ca.mcgill.cooperator.controller.BaseControllerIT;
 import ca.mcgill.cooperator.dao.CompanyRepository;
 import ca.mcgill.cooperator.dao.CoopDetailsRepository;
 import ca.mcgill.cooperator.dao.CourseOfferingRepository;
@@ -34,7 +34,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
-public class StudentGetCoopInfoIT extends ControllerIT {
+public class StudentGetCoopInfoIT extends BaseControllerIT {
 
     @Autowired private MockMvc mvc;
 

--- a/Backend/src/test/java/ca/mcgill/cooperator/cucumber/StudentUploadReportIT.java
+++ b/Backend/src/test/java/ca/mcgill/cooperator/cucumber/StudentUploadReportIT.java
@@ -4,7 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import ca.mcgill.cooperator.controller.ControllerIT;
+import ca.mcgill.cooperator.controller.BaseControllerIT;
 import ca.mcgill.cooperator.dao.CompanyRepository;
 import ca.mcgill.cooperator.dao.CoopDetailsRepository;
 import ca.mcgill.cooperator.dao.CourseOfferingRepository;
@@ -52,7 +52,7 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.request.RequestPostProcessor;
 import org.springframework.web.multipart.MultipartFile;
 
-public class StudentUploadReportIT extends ControllerIT {
+public class StudentUploadReportIT extends BaseControllerIT {
 
     @Autowired private MockMvc mvc;
 

--- a/Backend/src/test/java/ca/mcgill/cooperator/service/BaseServiceTest.java
+++ b/Backend/src/test/java/ca/mcgill/cooperator/service/BaseServiceTest.java
@@ -1,0 +1,6 @@
+package ca.mcgill.cooperator.service;
+
+public class BaseServiceTest {
+
+    static final String ERROR_PREFIX = "ERROR [Service]: ";
+}

--- a/Backend/src/test/java/ca/mcgill/cooperator/service/BaseServiceTest.java
+++ b/Backend/src/test/java/ca/mcgill/cooperator/service/BaseServiceTest.java
@@ -1,6 +1,156 @@
 package ca.mcgill.cooperator.service;
 
+import ca.mcgill.cooperator.model.Admin;
+import ca.mcgill.cooperator.model.Company;
+import ca.mcgill.cooperator.model.Coop;
+import ca.mcgill.cooperator.model.CoopDetails;
+import ca.mcgill.cooperator.model.CoopStatus;
+import ca.mcgill.cooperator.model.Course;
+import ca.mcgill.cooperator.model.CourseOffering;
+import ca.mcgill.cooperator.model.EmployerContact;
+import ca.mcgill.cooperator.model.EmployerReport;
+import ca.mcgill.cooperator.model.EmployerReportSection;
+import ca.mcgill.cooperator.model.Notification;
+import ca.mcgill.cooperator.model.ReportConfig;
+import ca.mcgill.cooperator.model.ReportResponseType;
+import ca.mcgill.cooperator.model.ReportSectionConfig;
+import ca.mcgill.cooperator.model.ReportStatus;
+import ca.mcgill.cooperator.model.Season;
+import ca.mcgill.cooperator.model.Student;
+import ca.mcgill.cooperator.model.StudentReport;
+import ca.mcgill.cooperator.model.StudentReportSection;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
+
 public class BaseServiceTest {
 
     static final String ERROR_PREFIX = "ERROR [Service]: ";
+
+    Admin createTestAdmin(AdminService service) {
+        Admin a = new Admin();
+        a = service.createAdmin("Lorraine", "Douglas", "lorraine@gmail.com");
+
+        return a;
+    }
+
+    Course createTestCourse(CourseService service) {
+        Course c = null;
+        c = service.createCourse("FACC200");
+        return c;
+    }
+
+    CourseOffering createTestCourseOffering(CourseOfferingService service, Course c) {
+        CourseOffering co = null;
+        co = service.createCourseOffering(2020, Season.WINTER, c);
+        return co;
+    }
+
+    Coop createTestCoop(CoopService service, CourseOffering co, Student s) {
+        Coop coop = new Coop();
+        coop = service.createCoop(CoopStatus.FUTURE, co, s);
+        return coop;
+    }
+
+    CoopDetails createTestCoopDetails(CoopDetailsService service, EmployerContact ec, Coop c) {
+        CoopDetails cd = new CoopDetails();
+        cd = service.createCoopDetails(20, 40, ec, c);
+        return cd;
+    }
+
+    Company createTestCompany(CompanyService service) {
+        Company c = new Company();
+        c =
+                service.createCompany(
+                        "Facebook",
+                        "Menlo Park",
+                        "California",
+                        "USA",
+                        new ArrayList<EmployerContact>());
+
+        return c;
+    }
+
+    EmployerContact createTestEmployerContact(EmployerContactService service, Company c) {
+        EmployerContact e = new EmployerContact();
+
+        e = service.createEmployerContact("Albert", "Kragl", "albert@kragl.com", "123456678", c);
+
+        return e;
+    }
+
+    Notification createTestNotification(
+            StudentService studentService, NotificationService notifService, Admin a) {
+        Student s =
+                studentService.createStudent("Albert", "Kragl", "albert@kragl.com", "123456789");
+        Notification n =
+                notifService.createNotification("Report Due", "Report Due by April 2020", s, a);
+
+        return n;
+    }
+
+    Notification createTestNotification(NotificationService service, Student s, Admin a) {
+        Notification notif = new Notification();
+        notif = service.createNotification("title", "body", s, a);
+        return notif;
+    }
+
+    Student createTestStudent(StudentService service) {
+        Student s = new Student();
+        s = service.createStudent("Susan", "Matuszewski", "susan@gmail.com", "260719281");
+
+        return s;
+    }
+
+    StudentReport createTestStudentReport(StudentReportService service, Coop c) {
+        StudentReport sr = new StudentReport();
+        File file = new File("src/test/resources/Test_Offer_Letter.pdf");
+        try {
+            MultipartFile multipartFile = new MockMultipartFile("file", new FileInputStream(file));
+
+            sr =
+                    service.createStudentReport(
+                            ReportStatus.COMPLETED, c, "Offer Letter", multipartFile);
+            return sr;
+        } catch (IOException e) {
+            return null;
+        }
+    }
+
+    StudentReportSection createTestStudentReportSection(
+            StudentReportSectionService service, ReportSectionConfig rsConfig, StudentReport sr) {
+        return service.createReportSection("This is a response", rsConfig, sr);
+    }
+
+    EmployerReport createTestEmployerReport(
+            EmployerReportService service, Coop c, EmployerContact ec) {
+        EmployerReport er = new EmployerReport();
+        File file = new File("src/test/resources/Test_Offer_Letter.pdf");
+        try {
+            MultipartFile multipartFile = new MockMultipartFile("file", new FileInputStream(file));
+
+            er =
+                    service.createEmployerReport(
+                            ReportStatus.COMPLETED, c, "Offer Letter", ec, multipartFile);
+            return er;
+        } catch (IOException e) {
+            return null;
+        }
+    }
+
+    EmployerReportSection createTestEmployerReportSection(
+            EmployerReportSectionService service, ReportSectionConfig rsConfig, EmployerReport er) {
+        return service.createReportSection("This is a response", rsConfig, er);
+    }
+
+    ReportSectionConfig createTestReportSectionConfig(
+            ReportConfigService rcService, ReportSectionConfigService rscService) {
+        ReportConfig reportConfig = rcService.createReportConfig(true, 14, true, "Evaluation");
+
+        return rscService.createReportSectionConfig(
+                "How was your co-op?", ReportResponseType.LONG_TEXT, reportConfig);
+    }
 }

--- a/Backend/src/test/java/ca/mcgill/cooperator/service/CooperatorServiceAdminTests.java
+++ b/Backend/src/test/java/ca/mcgill/cooperator/service/CooperatorServiceAdminTests.java
@@ -19,7 +19,7 @@ import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
 @ActiveProfiles("test")
-public class CooperatorServiceAdminTests {
+public class CooperatorServiceAdminTests extends BaseServiceTest {
 
     @Autowired AdminService adminService;
     @Autowired NotificationService notificationService;
@@ -60,7 +60,7 @@ public class CooperatorServiceAdminTests {
         try {
             adminService.createAdmin(firstName, lastName, email);
         } catch (IllegalArgumentException e) {
-            assertEquals("Admin email must be a valid email!", e.getMessage());
+            assertEquals(ERROR_PREFIX + "Admin email must be a valid email!", e.getMessage());
         }
     }
 
@@ -78,7 +78,8 @@ public class CooperatorServiceAdminTests {
         }
 
         assertEquals(
-                "Admin first name cannot be empty! Admin last name cannot be empty! Admin email cannot be empty!",
+                ERROR_PREFIX
+                        + "Admin first name cannot be empty! Admin last name cannot be empty! Admin email cannot be empty!",
                 error);
         assertEquals(0, adminService.getAllAdmins().size());
     }
@@ -97,7 +98,8 @@ public class CooperatorServiceAdminTests {
         }
 
         assertEquals(
-                "Admin first name cannot be empty! Admin last name cannot be empty! Admin email cannot be empty!",
+                ERROR_PREFIX
+                        + "Admin first name cannot be empty! Admin last name cannot be empty! Admin email cannot be empty!",
                 error);
         assertEquals(0, adminService.getAllAdmins().size());
     }
@@ -116,7 +118,8 @@ public class CooperatorServiceAdminTests {
         }
 
         assertEquals(
-                "Admin first name cannot be empty! "
+                ERROR_PREFIX
+                        + "Admin first name cannot be empty! "
                         + "Admin last name cannot be empty! "
                         + "Admin email cannot be empty!",
                 error);
@@ -204,7 +207,8 @@ public class CooperatorServiceAdminTests {
         }
 
         assertEquals(
-                "Admin to update cannot be null! "
+                ERROR_PREFIX
+                        + "Admin to update cannot be null! "
                         + "Admin first name cannot be empty! "
                         + "Admin last name cannot be empty! "
                         + "Admin email cannot be empty!",
@@ -246,7 +250,7 @@ public class CooperatorServiceAdminTests {
             error = e.getMessage();
         }
 
-        assertEquals("Admin to delete cannot be null!", error);
+        assertEquals(ERROR_PREFIX + "Admin to delete cannot be null!", error);
     }
 
     private Notification createTestNotification(Admin a) {

--- a/Backend/src/test/java/ca/mcgill/cooperator/service/CooperatorServiceAdminTests.java
+++ b/Backend/src/test/java/ca/mcgill/cooperator/service/CooperatorServiceAdminTests.java
@@ -8,7 +8,6 @@ import ca.mcgill.cooperator.dao.NotificationRepository;
 import ca.mcgill.cooperator.dao.StudentRepository;
 import ca.mcgill.cooperator.model.Admin;
 import ca.mcgill.cooperator.model.Notification;
-import ca.mcgill.cooperator.model.Student;
 import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -166,7 +165,7 @@ public class CooperatorServiceAdminTests extends BaseServiceTest {
             adminService.createAdmin(firstName, lastName, email);
             a = adminService.getAdmin(email);
 
-            n = createTestNotification(a);
+            n = createTestNotification(studentService, notificationService, a);
             List<Notification> notifications = a.getSentNotifications();
             notifications.add(n);
 
@@ -251,15 +250,5 @@ public class CooperatorServiceAdminTests extends BaseServiceTest {
         }
 
         assertEquals(ERROR_PREFIX + "Admin to delete cannot be null!", error);
-    }
-
-    private Notification createTestNotification(Admin a) {
-        Student s =
-                studentService.createStudent("Albert", "Kragl", "albert@kragl.com", "123456789");
-        Notification n =
-                notificationService.createNotification(
-                        "Report Due", "Report Due by April 2020", s, a);
-
-        return n;
     }
 }

--- a/Backend/src/test/java/ca/mcgill/cooperator/service/CooperatorServiceCompanyTests.java
+++ b/Backend/src/test/java/ca/mcgill/cooperator/service/CooperatorServiceCompanyTests.java
@@ -168,7 +168,7 @@ public class CooperatorServiceCompanyTests extends BaseServiceTest {
             c = companyService.getCompany(name, city, region, country);
 
             // Add new employee
-            ec = createTestEmployerContact(c);
+            ec = createTestEmployerContact(employerContactService, c);
             employees.add(ec);
 
             String updatedName = "Index Exchange";
@@ -286,15 +286,5 @@ public class CooperatorServiceCompanyTests extends BaseServiceTest {
         }
 
         assertEquals(ERROR_PREFIX + "Company to delete cannot be null!", error);
-    }
-
-    private EmployerContact createTestEmployerContact(Company c) {
-        EmployerContact e = new EmployerContact();
-
-        e =
-                employerContactService.createEmployerContact(
-                        "Albert", "Kragl", "albert@kragl.com", "123456678", c);
-
-        return e;
     }
 }

--- a/Backend/src/test/java/ca/mcgill/cooperator/service/CooperatorServiceCompanyTests.java
+++ b/Backend/src/test/java/ca/mcgill/cooperator/service/CooperatorServiceCompanyTests.java
@@ -18,7 +18,7 @@ import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
 @ActiveProfiles("test")
-public class CooperatorServiceCompanyTests {
+public class CooperatorServiceCompanyTests extends BaseServiceTest {
 
     @Autowired CompanyService companyService;
     @Autowired EmployerContactService employerContactService;
@@ -65,7 +65,8 @@ public class CooperatorServiceCompanyTests {
         }
 
         assertEquals(
-                "Company name cannot be empty! "
+                ERROR_PREFIX
+                        + "Company name cannot be empty! "
                         + "Company city cannot be empty! "
                         + "Company region cannot be empty! "
                         + "Company country cannot be empty! "
@@ -84,7 +85,8 @@ public class CooperatorServiceCompanyTests {
         }
 
         assertEquals(
-                "Company name cannot be empty! "
+                ERROR_PREFIX
+                        + "Company name cannot be empty! "
                         + "Company city cannot be empty! "
                         + "Company region cannot be empty! "
                         + "Company country cannot be empty! "
@@ -114,7 +116,7 @@ public class CooperatorServiceCompanyTests {
         } catch (IllegalArgumentException e) {
             error = e.getMessage();
         }
-        assertEquals("Company with this name and location already exists!", error);
+        assertEquals(ERROR_PREFIX + "Company with this name and location already exists!", error);
         assertEquals(companyService.getAllCompanies().size(), 1);
     }
 
@@ -213,7 +215,8 @@ public class CooperatorServiceCompanyTests {
         }
 
         assertEquals(
-                "Company to update cannot be null! "
+                ERROR_PREFIX
+                        + "Company to update cannot be null! "
                         + "Company name cannot be empty! "
                         + "Company city cannot be empty! "
                         + "Company region cannot be empty! "
@@ -243,7 +246,9 @@ public class CooperatorServiceCompanyTests {
 
             companyService.updateCompany(c, name, city, region, country, employees);
         } catch (IllegalArgumentException e) {
-            assertEquals("Company with this name and location already exists!", e.getMessage());
+            assertEquals(
+                    ERROR_PREFIX + "Company with this name and location already exists!",
+                    e.getMessage());
         }
 
         assertEquals(1, companyService.getAllCompanies().size());
@@ -280,7 +285,7 @@ public class CooperatorServiceCompanyTests {
             error = e.getMessage();
         }
 
-        assertEquals("Company to delete cannot be null!", error);
+        assertEquals(ERROR_PREFIX + "Company to delete cannot be null!", error);
     }
 
     private EmployerContact createTestEmployerContact(Company c) {

--- a/Backend/src/test/java/ca/mcgill/cooperator/service/CooperatorServiceCoopDetailsTests.java
+++ b/Backend/src/test/java/ca/mcgill/cooperator/service/CooperatorServiceCoopDetailsTests.java
@@ -30,7 +30,7 @@ import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
 @ActiveProfiles("test")
-public class CooperatorServiceCoopDetailsTests {
+public class CooperatorServiceCoopDetailsTests extends BaseServiceTest {
 
     @Autowired CoopDetailsRepository coopDetailsRepository;
     @Autowired CoopRepository coopRepository;
@@ -100,7 +100,9 @@ public class CooperatorServiceCoopDetailsTests {
             error = e.getMessage();
         }
 
-        assertEquals("Employer Contact cannot be null! " + "Co-op cannot be null!", error);
+        assertEquals(
+                ERROR_PREFIX + "Employer Contact cannot be null! " + "Co-op cannot be null!",
+                error);
         assertEquals(0, coopDetailsService.getAllCoopDetails().size());
     }
 
@@ -116,7 +118,8 @@ public class CooperatorServiceCoopDetailsTests {
         }
 
         assertEquals(
-                "Pay Per Hour is invalid! "
+                ERROR_PREFIX
+                        + "Pay Per Hour is invalid! "
                         + "Hours Per Week is invalid! "
                         + "Employer Contact cannot be null! "
                         + "Co-op cannot be null!",
@@ -185,7 +188,7 @@ public class CooperatorServiceCoopDetailsTests {
             error = e.getMessage();
         }
 
-        assertEquals("Co-op Details to update cannot be null!", error);
+        assertEquals(ERROR_PREFIX + "Co-op Details to update cannot be null!", error);
         assertEquals(1, coopDetailsService.getAllCoopDetails().size());
     }
 
@@ -227,7 +230,7 @@ public class CooperatorServiceCoopDetailsTests {
             error = e.getMessage();
         }
 
-        assertEquals("Co-op Details to delete cannot be null!", error);
+        assertEquals(ERROR_PREFIX + "Co-op Details to delete cannot be null!", error);
     }
 
     private Course createTestCourse() {

--- a/Backend/src/test/java/ca/mcgill/cooperator/service/CooperatorServiceCoopDetailsTests.java
+++ b/Backend/src/test/java/ca/mcgill/cooperator/service/CooperatorServiceCoopDetailsTests.java
@@ -13,13 +13,10 @@ import ca.mcgill.cooperator.dao.StudentRepository;
 import ca.mcgill.cooperator.model.Company;
 import ca.mcgill.cooperator.model.Coop;
 import ca.mcgill.cooperator.model.CoopDetails;
-import ca.mcgill.cooperator.model.CoopStatus;
 import ca.mcgill.cooperator.model.Course;
 import ca.mcgill.cooperator.model.CourseOffering;
 import ca.mcgill.cooperator.model.EmployerContact;
-import ca.mcgill.cooperator.model.Season;
 import ca.mcgill.cooperator.model.Student;
-import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -69,12 +66,12 @@ public class CooperatorServiceCoopDetailsTests extends BaseServiceTest {
     public void testCreateCoopDetails() {
         int payPerHour = 2000;
         int hoursPerWeek = 40;
-        Company company = createTestCompany();
-        EmployerContact ec = createTestEmployerContact(company);
-        Course course = createTestCourse();
-        CourseOffering courseOffering = createTestCourseOffering(course);
-        Student s = createTestStudent();
-        Coop coop = createTestCoop(courseOffering, s);
+        Company company = createTestCompany(companyService);
+        EmployerContact ec = createTestEmployerContact(employerContactService, company);
+        Course course = createTestCourse(courseService);
+        CourseOffering courseOffering = createTestCourseOffering(courseOfferingService, course);
+        Student s = createTestStudent(studentService);
+        Coop coop = createTestCoop(coopService, courseOffering, s);
 
         try {
             coopDetailsService.createCoopDetails(payPerHour, hoursPerWeek, ec, coop);
@@ -132,12 +129,12 @@ public class CooperatorServiceCoopDetailsTests extends BaseServiceTest {
         CoopDetails cd = null;
         int payPerHour = 2000;
         int hoursPerWeek = 40;
-        Company company = createTestCompany();
-        EmployerContact ec = createTestEmployerContact(company);
-        Course course = createTestCourse();
-        CourseOffering courseOffering = createTestCourseOffering(course);
-        Student s = createTestStudent();
-        Coop coop = createTestCoop(courseOffering, s);
+        Company company = createTestCompany(companyService);
+        EmployerContact ec = createTestEmployerContact(employerContactService, company);
+        Course course = createTestCourse(courseService);
+        CourseOffering courseOffering = createTestCourseOffering(courseOfferingService, course);
+        Student s = createTestStudent(studentService);
+        Coop coop = createTestCoop(coopService, courseOffering, s);
 
         try {
             cd = coopDetailsService.createCoopDetails(payPerHour, hoursPerWeek, ec, coop);
@@ -166,12 +163,12 @@ public class CooperatorServiceCoopDetailsTests extends BaseServiceTest {
         CoopDetails cd = null;
         int payPerHour = 20;
         int hoursPerWeek = 40;
-        Company company = createTestCompany();
-        EmployerContact ec = createTestEmployerContact(company);
-        Course course = createTestCourse();
-        CourseOffering courseOffering = createTestCourseOffering(course);
-        Student s = createTestStudent();
-        Coop coop = createTestCoop(courseOffering, s);
+        Company company = createTestCompany(companyService);
+        EmployerContact ec = createTestEmployerContact(employerContactService, company);
+        Course course = createTestCourse(courseService);
+        CourseOffering courseOffering = createTestCourseOffering(courseOfferingService, course);
+        Student s = createTestStudent(studentService);
+        Coop coop = createTestCoop(coopService, courseOffering, s);
 
         try {
             coopDetailsService.createCoopDetails(payPerHour, hoursPerWeek, ec, coop);
@@ -197,12 +194,12 @@ public class CooperatorServiceCoopDetailsTests extends BaseServiceTest {
         CoopDetails cd = null;
         int payPerHour = 20;
         int hoursPerWeek = 40;
-        Company company = createTestCompany();
-        EmployerContact ec = createTestEmployerContact(company);
-        Course course = createTestCourse();
-        CourseOffering courseOffering = createTestCourseOffering(course);
-        Student s = createTestStudent();
-        Coop coop = createTestCoop(courseOffering, s);
+        Company company = createTestCompany(companyService);
+        EmployerContact ec = createTestEmployerContact(employerContactService, company);
+        Course course = createTestCourse(courseService);
+        CourseOffering courseOffering = createTestCourseOffering(courseOfferingService, course);
+        Student s = createTestStudent(studentService);
+        Coop coop = createTestCoop(coopService, courseOffering, s);
 
         try {
             cd = coopDetailsService.createCoopDetails(payPerHour, hoursPerWeek, ec, coop);
@@ -231,51 +228,5 @@ public class CooperatorServiceCoopDetailsTests extends BaseServiceTest {
         }
 
         assertEquals(ERROR_PREFIX + "Co-op Details to delete cannot be null!", error);
-    }
-
-    private Course createTestCourse() {
-        Course c = null;
-        c = courseService.createCourse("FACC200");
-        return c;
-    }
-
-    private CourseOffering createTestCourseOffering(Course c) {
-        CourseOffering co = null;
-        co = courseOfferingService.createCourseOffering(2020, Season.WINTER, c);
-        return co;
-    }
-
-    private Coop createTestCoop(CourseOffering co, Student s) {
-        Coop coop = new Coop();
-        coop = coopService.createCoop(CoopStatus.FUTURE, co, s);
-        return coop;
-    }
-
-    private Company createTestCompany() {
-        Company c = new Company();
-        c =
-                companyService.createCompany(
-                        "Facebook",
-                        "Menlo Park",
-                        "California",
-                        "USA",
-                        new ArrayList<EmployerContact>());
-
-        return c;
-    }
-
-    private EmployerContact createTestEmployerContact(Company c) {
-        EmployerContact ec = new EmployerContact();
-        ec =
-                employerContactService.createEmployerContact(
-                        "Emma", "Eags", "eags@gmail.com", "2143546578", c);
-        return ec;
-    }
-
-    private Student createTestStudent() {
-        Student s = new Student();
-        s = studentService.createStudent("Susan", "Matuszewski", "susan@gmail.com", "260719281");
-
-        return s;
     }
 }

--- a/Backend/src/test/java/ca/mcgill/cooperator/service/CooperatorServiceCoopTests.java
+++ b/Backend/src/test/java/ca/mcgill/cooperator/service/CooperatorServiceCoopTests.java
@@ -18,10 +18,8 @@ import ca.mcgill.cooperator.model.Course;
 import ca.mcgill.cooperator.model.CourseOffering;
 import ca.mcgill.cooperator.model.EmployerContact;
 import ca.mcgill.cooperator.model.EmployerReport;
-import ca.mcgill.cooperator.model.Season;
 import ca.mcgill.cooperator.model.Student;
 import ca.mcgill.cooperator.model.StudentReport;
-import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -72,9 +70,9 @@ public class CooperatorServiceCoopTests extends BaseServiceTest {
     @Test
     public void testCreateCoop() {
         CoopStatus status = CoopStatus.IN_PROGRESS;
-        Course course = createTestCourse();
-        CourseOffering courseOffering = createTestCourseOffering(course);
-        Student student = createTestStudent();
+        Course course = createTestCourse(courseService);
+        CourseOffering courseOffering = createTestCourseOffering(courseOfferingService, course);
+        Student student = createTestStudent(studentService);
 
         try {
             coopService.createCoop(status, courseOffering, student);
@@ -110,9 +108,9 @@ public class CooperatorServiceCoopTests extends BaseServiceTest {
     @Test
     public void testUpdateCoop() {
         CoopStatus status = CoopStatus.IN_PROGRESS;
-        Course course = createTestCourse();
-        CourseOffering courseOffering = createTestCourseOffering(course);
-        Student student = createTestStudent();
+        Course course = createTestCourse(courseService);
+        CourseOffering courseOffering = createTestCourseOffering(courseOfferingService, course);
+        Student student = createTestStudent(studentService);
         Coop c = new Coop();
         try {
             c = coopService.createCoop(status, courseOffering, student);
@@ -123,9 +121,9 @@ public class CooperatorServiceCoopTests extends BaseServiceTest {
         assertEquals(1, coopService.getAllCoops().size());
 
         status = CoopStatus.COMPLETED;
-        Company company = createTestCompany();
-        EmployerContact ec = createTestEmployerContact(company);
-        CoopDetails cd = createTestCoopDetails(ec, c);
+        Company company = createTestCompany(companyService);
+        EmployerContact ec = createTestEmployerContact(employerContactService, company);
+        CoopDetails cd = createTestCoopDetails(coopDetailsService, ec, c);
         Set<EmployerReport> employerReports = new HashSet<EmployerReport>();
         Set<StudentReport> studentReports = new HashSet<StudentReport>();
 
@@ -156,9 +154,9 @@ public class CooperatorServiceCoopTests extends BaseServiceTest {
     @Test
     public void testUpdateCoopInvalid() {
         CoopStatus status = CoopStatus.IN_PROGRESS;
-        Course course = createTestCourse();
-        CourseOffering courseOffering = createTestCourseOffering(course);
-        Student student = createTestStudent();
+        Course course = createTestCourse(courseService);
+        CourseOffering courseOffering = createTestCourseOffering(courseOfferingService, course);
+        Student student = createTestStudent(studentService);
 
         try {
             coopService.createCoop(status, courseOffering, student);
@@ -182,9 +180,9 @@ public class CooperatorServiceCoopTests extends BaseServiceTest {
     @Test
     public void testDeleteCoop() {
         CoopStatus status = CoopStatus.IN_PROGRESS;
-        Course course = createTestCourse();
-        CourseOffering courseOffering = createTestCourseOffering(course);
-        Student student = createTestStudent();
+        Course course = createTestCourse(courseService);
+        CourseOffering courseOffering = createTestCourseOffering(courseOfferingService, course);
+        Student student = createTestStudent(studentService);
         Coop c = new Coop();
         try {
             c = coopService.createCoop(status, courseOffering, student);
@@ -201,50 +199,5 @@ public class CooperatorServiceCoopTests extends BaseServiceTest {
         }
 
         assertEquals(0, coopService.getAllCoops().size());
-    }
-
-    private Course createTestCourse() {
-        Course c = null;
-        c = courseService.createCourse("FACC200");
-        return c;
-    }
-
-    private CourseOffering createTestCourseOffering(Course c) {
-        CourseOffering co = null;
-        co = courseOfferingService.createCourseOffering(2020, Season.WINTER, c);
-        return co;
-    }
-
-    private Student createTestStudent() {
-        Student s = new Student();
-        s = studentService.createStudent("Susan", "Matuszewski", "susan@gmail.com", "260719281");
-
-        return s;
-    }
-
-    private CoopDetails createTestCoopDetails(EmployerContact ec, Coop c) {
-        CoopDetails cd = new CoopDetails();
-        cd = coopDetailsService.createCoopDetails(20, 40, ec, c);
-        return cd;
-    }
-
-    private EmployerContact createTestEmployerContact(Company c) {
-        EmployerContact ec;
-        ec =
-                employerContactService.createEmployerContact(
-                        "Albert", "Kragl", "albert@gmail.com", "123456789", c);
-        return ec;
-    }
-
-    private Company createTestCompany() {
-        Company c = new Company();
-        c =
-                companyService.createCompany(
-                        "Facebook",
-                        "Menlo Park",
-                        "California",
-                        "USA",
-                        new ArrayList<EmployerContact>());
-        return c;
     }
 }

--- a/Backend/src/test/java/ca/mcgill/cooperator/service/CooperatorServiceCoopTests.java
+++ b/Backend/src/test/java/ca/mcgill/cooperator/service/CooperatorServiceCoopTests.java
@@ -34,9 +34,8 @@ import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
 @ActiveProfiles("test")
-public class CooperatorServiceCoopTests {
+public class CooperatorServiceCoopTests extends BaseServiceTest {
 
-    // TODO: add Service and Repository class imports here
     @Autowired CoopService coopService;
     @Autowired CourseOfferingService courseOfferingService;
     @Autowired StudentService studentService;
@@ -101,7 +100,8 @@ public class CooperatorServiceCoopTests {
 
         assertEquals(0, coopService.getAllCoops().size());
         assertEquals(
-                "Co-op Status cannot be null. "
+                ERROR_PREFIX
+                        + "Co-op Status cannot be null. "
                         + "Course Offering cannot be null. "
                         + "Student cannot be null.",
                 error);
@@ -176,7 +176,7 @@ public class CooperatorServiceCoopTests {
         }
 
         assertEquals(1, coopService.getAllCoops().size());
-        assertEquals("Co-op to update cannot be null!", error);
+        assertEquals(ERROR_PREFIX + "Co-op to update cannot be null!", error);
     }
 
     @Test

--- a/Backend/src/test/java/ca/mcgill/cooperator/service/CooperatorServiceCourseOfferingTests.java
+++ b/Backend/src/test/java/ca/mcgill/cooperator/service/CooperatorServiceCourseOfferingTests.java
@@ -17,7 +17,7 @@ import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
 @ActiveProfiles("test")
-public class CooperatorServiceCourseOfferingTests {
+public class CooperatorServiceCourseOfferingTests extends BaseServiceTest {
 
     @Autowired CourseService courseService;
     @Autowired CourseOfferingService courseOfferingService;
@@ -62,7 +62,7 @@ public class CooperatorServiceCourseOfferingTests {
             courseOfferingService.createCourseOffering(0, null, null);
         } catch (IllegalArgumentException e) {
             assertEquals(
-                    "Year is invalid! Season cannot be null! Course cannot be null!",
+                    ERROR_PREFIX + "Year is invalid! Season cannot be null! Course cannot be null!",
                     e.getMessage());
         }
 
@@ -140,7 +140,8 @@ public class CooperatorServiceCourseOfferingTests {
             courseOfferingService.updateCourseOffering(null, year2, season2, c2);
 
         } catch (IllegalArgumentException e) {
-            assertEquals("Course Offering to update cannot be null!", e.getMessage());
+            assertEquals(
+                    ERROR_PREFIX + "Course Offering to update cannot be null!", e.getMessage());
         }
 
         co = courseOfferingService.getAllCourseOfferings().get(0);

--- a/Backend/src/test/java/ca/mcgill/cooperator/service/CooperatorServiceCourseTests.java
+++ b/Backend/src/test/java/ca/mcgill/cooperator/service/CooperatorServiceCourseTests.java
@@ -16,7 +16,7 @@ import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
 @ActiveProfiles("test")
-public class CooperatorServiceCourseTests {
+public class CooperatorServiceCourseTests extends BaseServiceTest {
 
     @Autowired CourseService courseService;
 
@@ -50,7 +50,7 @@ public class CooperatorServiceCourseTests {
         } catch (IllegalArgumentException e) {
             error = e.getMessage();
         }
-        assertEquals("Course name cannot be empty!", error);
+        assertEquals(ERROR_PREFIX + "Course name cannot be empty!", error);
         assertEquals(0, courseService.getAllCourses().size());
     }
 
@@ -63,7 +63,7 @@ public class CooperatorServiceCourseTests {
         } catch (IllegalArgumentException e) {
             error = e.getMessage();
         }
-        assertEquals("Course name cannot be empty!", error);
+        assertEquals(ERROR_PREFIX + "Course name cannot be empty!", error);
         assertEquals(0, courseService.getAllCourses().size());
     }
 
@@ -76,7 +76,7 @@ public class CooperatorServiceCourseTests {
         } catch (IllegalArgumentException e) {
             error = e.getMessage();
         }
-        assertEquals("Course name cannot be empty!", error);
+        assertEquals(ERROR_PREFIX + "Course name cannot be empty!", error);
         assertEquals(0, courseService.getAllCourses().size());
     }
 
@@ -90,7 +90,9 @@ public class CooperatorServiceCourseTests {
         } catch (IllegalArgumentException e) {
             error = e.getMessage();
         }
-        assertEquals("Course to update cannot be null! " + "Course name cannot be empty!", error);
+        assertEquals(
+                ERROR_PREFIX + "Course to update cannot be null! " + "Course name cannot be empty!",
+                error);
         assertEquals(1, courseService.getAllCourses().size());
         assertEquals(name, courseService.getAllCourses().get(0).getName());
     }
@@ -139,6 +141,6 @@ public class CooperatorServiceCourseTests {
         } catch (IllegalArgumentException e) {
             error = e.getMessage();
         }
-        assertEquals(error, "Course to delete cannot be null!");
+        assertEquals(ERROR_PREFIX + "Course to delete cannot be null!", error);
     }
 }

--- a/Backend/src/test/java/ca/mcgill/cooperator/service/CooperatorServiceEmployerContactTests.java
+++ b/Backend/src/test/java/ca/mcgill/cooperator/service/CooperatorServiceEmployerContactTests.java
@@ -33,7 +33,7 @@ import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
 @ActiveProfiles("test")
-public class CooperatorServiceEmployerContactTests {
+public class CooperatorServiceEmployerContactTests extends BaseServiceTest {
 
     @Autowired EmployerContactService employerContactService;
     @Autowired CompanyService companyService;
@@ -100,7 +100,8 @@ public class CooperatorServiceEmployerContactTests {
             employerContactService.createEmployerContact(
                     firstName, lastName, email, phoneNumber, c);
         } catch (IllegalArgumentException e) {
-            assertEquals("Employer Contact email must be a valid email!", e.getMessage());
+            assertEquals(
+                    ERROR_PREFIX + "Employer Contact email must be a valid email!", e.getMessage());
         }
     }
 
@@ -116,7 +117,9 @@ public class CooperatorServiceEmployerContactTests {
             employerContactService.createEmployerContact(
                     firstName, lastName, email, phoneNumber, c);
         } catch (IllegalArgumentException e) {
-            assertEquals("Employer Contact phone number must be a valid number!", e.getMessage());
+            assertEquals(
+                    ERROR_PREFIX + "Employer Contact phone number must be a valid number!",
+                    e.getMessage());
         }
     }
 
@@ -137,7 +140,8 @@ public class CooperatorServiceEmployerContactTests {
             error = e.getMessage();
         }
         assertEquals(
-                "Employer Contact first name cannot be empty!"
+                ERROR_PREFIX
+                        + "Employer Contact first name cannot be empty!"
                         + " Employer Contact last name cannot be empty!"
                         + " Employer Contact email cannot be empty!"
                         + " Employer Contact phone number cannot be empty!"
@@ -163,7 +167,8 @@ public class CooperatorServiceEmployerContactTests {
             error = e.getMessage();
         }
         assertEquals(
-                "Employer Contact first name cannot be empty!"
+                ERROR_PREFIX
+                        + "Employer Contact first name cannot be empty!"
                         + " Employer Contact last name cannot be empty!"
                         + " Employer Contact email cannot be empty!"
                         + " Employer Contact phone number cannot be empty!"
@@ -189,7 +194,8 @@ public class CooperatorServiceEmployerContactTests {
             error = e.getMessage();
         }
         assertEquals(
-                "Employer Contact first name cannot be empty!"
+                ERROR_PREFIX
+                        + "Employer Contact first name cannot be empty!"
                         + " Employer Contact last name cannot be empty!"
                         + " Employer Contact email cannot be empty!"
                         + " Employer Contact phone number cannot be empty!"
@@ -310,7 +316,8 @@ public class CooperatorServiceEmployerContactTests {
         }
 
         assertEquals(
-                "Employer Contact first name cannot be empty!"
+                ERROR_PREFIX
+                        + "Employer Contact first name cannot be empty!"
                         + " Employer Contact last name cannot be empty!"
                         + " Employer Contact email cannot be empty!"
                         + " Employer Contact phone number cannot be empty!",
@@ -356,7 +363,7 @@ public class CooperatorServiceEmployerContactTests {
             error = e.getMessage();
         }
 
-        assertEquals("Employer Contact to delete cannot be null!", error);
+        assertEquals(ERROR_PREFIX + "Employer Contact to delete cannot be null!", error);
     }
 
     private Company createTestCompany() {

--- a/Backend/src/test/java/ca/mcgill/cooperator/service/CooperatorServiceEmployerContactTests.java
+++ b/Backend/src/test/java/ca/mcgill/cooperator/service/CooperatorServiceEmployerContactTests.java
@@ -13,14 +13,11 @@ import ca.mcgill.cooperator.dao.StudentRepository;
 import ca.mcgill.cooperator.model.Company;
 import ca.mcgill.cooperator.model.Coop;
 import ca.mcgill.cooperator.model.CoopDetails;
-import ca.mcgill.cooperator.model.CoopStatus;
 import ca.mcgill.cooperator.model.Course;
 import ca.mcgill.cooperator.model.CourseOffering;
 import ca.mcgill.cooperator.model.EmployerContact;
 import ca.mcgill.cooperator.model.EmployerReport;
-import ca.mcgill.cooperator.model.Season;
 import ca.mcgill.cooperator.model.Student;
-import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -74,7 +71,7 @@ public class CooperatorServiceEmployerContactTests extends BaseServiceTest {
         String lastName = "Hooley";
         String email = "phooley@gmail.com";
         String phoneNumber = "0123456789";
-        Company c = createTestCompany();
+        Company c = createTestCompany(companyService);
 
         try {
             employerContactService.createEmployerContact(
@@ -94,7 +91,7 @@ public class CooperatorServiceEmployerContactTests extends BaseServiceTest {
         String lastName = "Hooley";
         String email = "abcdefg";
         String phoneNumber = "0123456789";
-        Company c = createTestCompany();
+        Company c = createTestCompany(companyService);
 
         try {
             employerContactService.createEmployerContact(
@@ -111,7 +108,7 @@ public class CooperatorServiceEmployerContactTests extends BaseServiceTest {
         String lastName = "Hooley";
         String email = "phooley@gmail.com";
         String phoneNumber = "asdfdgf";
-        Company c = createTestCompany();
+        Company c = createTestCompany(companyService);
 
         try {
             employerContactService.createEmployerContact(
@@ -210,15 +207,15 @@ public class CooperatorServiceEmployerContactTests extends BaseServiceTest {
         String lastName = "Hooley";
         String email = "phooley@gmail.com";
         String phoneNumber = "0123456789";
-        Company c = createTestCompany();
+        Company c = createTestCompany(companyService);
         EmployerContact ec = null;
 
         // course->course offering->coops->coop details
         CoopDetails cd = null;
-        Course course = createTestCourse();
-        CourseOffering co = createTestCourseOffering(course);
-        Student s = createTestStudent();
-        Coop coop = createTestCoop(co, s);
+        Course course = createTestCourse(courseService);
+        CourseOffering co = createTestCourseOffering(courseOfferingService, course);
+        Student s = createTestStudent(studentService);
+        Coop coop = createTestCoop(coopService, co, s);
         Set<CoopDetails> coopDetails = new HashSet<CoopDetails>();
 
         try {
@@ -227,7 +224,7 @@ public class CooperatorServiceEmployerContactTests extends BaseServiceTest {
                             firstName, lastName, email, phoneNumber, c);
             ec = employerContactService.getEmployerContact(ec.getId());
 
-            cd = createTestCoopDetails(ec, coop);
+            cd = createTestCoopDetails(coopDetailsService, ec, coop);
             coopDetails.add(cd);
 
             Set<EmployerReport> reports = new HashSet<EmployerReport>();
@@ -255,7 +252,7 @@ public class CooperatorServiceEmployerContactTests extends BaseServiceTest {
         String lastName = "Hooley";
         String email = "phooley@gmail.com";
         String phoneNumber = "0123456789";
-        Company c = createTestCompany();
+        Company c = createTestCompany(companyService);
 
         EmployerContact ec = null;
         try {
@@ -295,7 +292,7 @@ public class CooperatorServiceEmployerContactTests extends BaseServiceTest {
         String lastName = "Hooley";
         String email = "phooley@gmail.com";
         String phoneNumber = "0123456789";
-        Company c = createTestCompany();
+        Company c = createTestCompany(companyService);
 
         EmployerContact ec = null;
         try {
@@ -338,7 +335,7 @@ public class CooperatorServiceEmployerContactTests extends BaseServiceTest {
         String lastName = "Hooley";
         String email = "phooley@gmail.com";
         String phoneNumber = "0123456789";
-        Company c = createTestCompany();
+        Company c = createTestCompany(companyService);
 
         EmployerContact ec = null;
         try {
@@ -364,49 +361,5 @@ public class CooperatorServiceEmployerContactTests extends BaseServiceTest {
         }
 
         assertEquals(ERROR_PREFIX + "Employer Contact to delete cannot be null!", error);
-    }
-
-    private Company createTestCompany() {
-        Company c = new Company();
-        c =
-                companyService.createCompany(
-                        "Facebook",
-                        "Menlo Park",
-                        "California",
-                        "USA",
-                        new ArrayList<EmployerContact>());
-
-        return c;
-    }
-
-    private CoopDetails createTestCoopDetails(EmployerContact ec, Coop c) {
-        CoopDetails cd = new CoopDetails();
-        cd = coopDetailsService.createCoopDetails(20, 40, ec, c);
-        return cd;
-    }
-
-    private Course createTestCourse() {
-        Course c = null;
-        c = courseService.createCourse("FACC200");
-        return c;
-    }
-
-    private CourseOffering createTestCourseOffering(Course c) {
-        CourseOffering co = null;
-        co = courseOfferingService.createCourseOffering(2020, Season.WINTER, c);
-        return co;
-    }
-
-    private Student createTestStudent() {
-        Student s = new Student();
-        s = studentService.createStudent("Susan", "Matuszewski", "susan@gmail.com", "260719281");
-
-        return s;
-    }
-
-    private Coop createTestCoop(CourseOffering co, Student s) {
-        Coop coop = new Coop();
-        coop = coopService.createCoop(CoopStatus.FUTURE, co, s);
-        return coop;
     }
 }

--- a/Backend/src/test/java/ca/mcgill/cooperator/service/CooperatorServiceEmployerReportSectionTests.java
+++ b/Backend/src/test/java/ca/mcgill/cooperator/service/CooperatorServiceEmployerReportSectionTests.java
@@ -13,31 +13,20 @@ import ca.mcgill.cooperator.dao.EmployerReportSectionRepository;
 import ca.mcgill.cooperator.dao.StudentRepository;
 import ca.mcgill.cooperator.model.Company;
 import ca.mcgill.cooperator.model.Coop;
-import ca.mcgill.cooperator.model.CoopStatus;
 import ca.mcgill.cooperator.model.Course;
 import ca.mcgill.cooperator.model.CourseOffering;
 import ca.mcgill.cooperator.model.EmployerContact;
 import ca.mcgill.cooperator.model.EmployerReport;
 import ca.mcgill.cooperator.model.EmployerReportSection;
-import ca.mcgill.cooperator.model.ReportConfig;
-import ca.mcgill.cooperator.model.ReportResponseType;
 import ca.mcgill.cooperator.model.ReportSectionConfig;
-import ca.mcgill.cooperator.model.ReportStatus;
-import ca.mcgill.cooperator.model.Season;
 import ca.mcgill.cooperator.model.Student;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.web.multipart.MultipartFile;
 
 @SpringBootTest
 @ActiveProfiles("test")
@@ -85,14 +74,15 @@ public class CooperatorServiceEmployerReportSectionTests extends BaseServiceTest
     @Test
     public void createReportSection() {
         String response = "This is a response";
-        Course course = createTestCourse();
-        CourseOffering courseOffering = createTestCourseOffering(course);
-        Student s = createTestStudent();
-        Coop coop = createTestCoop(courseOffering, s);
-        Company c = createTestCompany();
-        EmployerContact ec = createTestEmployerContact(c);
-        ReportSectionConfig rsConfig = createTestReportSectionConfig();
-        EmployerReport er = createTestEmployerReport(coop, ec);
+        Course course = createTestCourse(courseService);
+        CourseOffering courseOffering = createTestCourseOffering(courseOfferingService, course);
+        Student s = createTestStudent(studentService);
+        Coop coop = createTestCoop(coopService, courseOffering, s);
+        Company c = createTestCompany(companyService);
+        EmployerContact ec = createTestEmployerContact(employerContactService, c);
+        ReportSectionConfig rsConfig =
+                createTestReportSectionConfig(reportConfigService, reportSectionConfigService);
+        EmployerReport er = createTestEmployerReport(employerReportService, coop, ec);
 
         try {
             employerReportSectionService.createReportSection(response, rsConfig, er);
@@ -161,14 +151,15 @@ public class CooperatorServiceEmployerReportSectionTests extends BaseServiceTest
     public void updateReportSection() {
         EmployerReportSection rs = null;
         String response = "This is a response";
-        Course course = createTestCourse();
-        CourseOffering courseOffering = createTestCourseOffering(course);
-        Student s = createTestStudent();
-        Coop coop = createTestCoop(courseOffering, s);
-        Company c = createTestCompany();
-        EmployerContact ec = createTestEmployerContact(c);
-        ReportSectionConfig rsConfig = createTestReportSectionConfig();
-        EmployerReport er = createTestEmployerReport(coop, ec);
+        Course course = createTestCourse(courseService);
+        CourseOffering courseOffering = createTestCourseOffering(courseOfferingService, course);
+        Student s = createTestStudent(studentService);
+        Coop coop = createTestCoop(coopService, courseOffering, s);
+        Company c = createTestCompany(companyService);
+        EmployerContact ec = createTestEmployerContact(employerContactService, c);
+        ReportSectionConfig rsConfig =
+                createTestReportSectionConfig(reportConfigService, reportSectionConfigService);
+        EmployerReport er = createTestEmployerReport(employerReportService, coop, ec);
 
         try {
             rs = employerReportSectionService.createReportSection(response, rsConfig, er);
@@ -197,14 +188,15 @@ public class CooperatorServiceEmployerReportSectionTests extends BaseServiceTest
     public void updateReportSectionInvalid() {
         EmployerReportSection rs = null;
         String response = "This is a response";
-        Course course = createTestCourse();
-        CourseOffering courseOffering = createTestCourseOffering(course);
-        Student s = createTestStudent();
-        Coop coop = createTestCoop(courseOffering, s);
-        Company c = createTestCompany();
-        EmployerContact ec = createTestEmployerContact(c);
-        ReportSectionConfig rsConfig = createTestReportSectionConfig();
-        EmployerReport er = createTestEmployerReport(coop, ec);
+        Course course = createTestCourse(courseService);
+        CourseOffering courseOffering = createTestCourseOffering(courseOfferingService, course);
+        Student s = createTestStudent(studentService);
+        Coop coop = createTestCoop(coopService, courseOffering, s);
+        Company c = createTestCompany(companyService);
+        EmployerContact ec = createTestEmployerContact(employerContactService, c);
+        ReportSectionConfig rsConfig =
+                createTestReportSectionConfig(reportConfigService, reportSectionConfigService);
+        EmployerReport er = createTestEmployerReport(employerReportService, coop, ec);
 
         try {
             employerReportSectionService.createReportSection(response, rsConfig, er);
@@ -229,14 +221,15 @@ public class CooperatorServiceEmployerReportSectionTests extends BaseServiceTest
     @Test
     public void updateReportSectionNull() {
         String response = "This is a response";
-        Course course = createTestCourse();
-        CourseOffering courseOffering = createTestCourseOffering(course);
-        Student s = createTestStudent();
-        Coop coop = createTestCoop(courseOffering, s);
-        Company c = createTestCompany();
-        EmployerContact ec = createTestEmployerContact(c);
-        ReportSectionConfig rsConfig = createTestReportSectionConfig();
-        EmployerReport er = createTestEmployerReport(coop, ec);
+        Course course = createTestCourse(courseService);
+        CourseOffering courseOffering = createTestCourseOffering(courseOfferingService, course);
+        Student s = createTestStudent(studentService);
+        Coop coop = createTestCoop(coopService, courseOffering, s);
+        Company c = createTestCompany(companyService);
+        EmployerContact ec = createTestEmployerContact(employerContactService, c);
+        ReportSectionConfig rsConfig =
+                createTestReportSectionConfig(reportConfigService, reportSectionConfigService);
+        EmployerReport er = createTestEmployerReport(employerReportService, coop, ec);
 
         try {
             employerReportSectionService.createReportSection(response, rsConfig, er);
@@ -258,14 +251,15 @@ public class CooperatorServiceEmployerReportSectionTests extends BaseServiceTest
     public void deleteReportSection() {
         EmployerReportSection rs = null;
         String response = "This is a response";
-        Course course = createTestCourse();
-        CourseOffering courseOffering = createTestCourseOffering(course);
-        Student s = createTestStudent();
-        Coop coop = createTestCoop(courseOffering, s);
-        Company c = createTestCompany();
-        EmployerContact ec = createTestEmployerContact(c);
-        ReportSectionConfig rsConfig = createTestReportSectionConfig();
-        EmployerReport er = createTestEmployerReport(coop, ec);
+        Course course = createTestCourse(courseService);
+        CourseOffering courseOffering = createTestCourseOffering(courseOfferingService, course);
+        Student s = createTestStudent(studentService);
+        Coop coop = createTestCoop(coopService, courseOffering, s);
+        Company c = createTestCompany(companyService);
+        EmployerContact ec = createTestEmployerContact(employerContactService, c);
+        ReportSectionConfig rsConfig =
+                createTestReportSectionConfig(reportConfigService, reportSectionConfigService);
+        EmployerReport er = createTestEmployerReport(employerReportService, coop, ec);
 
         try {
             rs = employerReportSectionService.createReportSection(response, rsConfig, er);
@@ -284,19 +278,19 @@ public class CooperatorServiceEmployerReportSectionTests extends BaseServiceTest
 
     @Test
     public void deleteReportSectionEmployerReport() {
-        EmployerReportSection rs = null;
         String response = "This is a response";
-        Course course = createTestCourse();
-        CourseOffering courseOffering = createTestCourseOffering(course);
-        Student s = createTestStudent();
-        Coop coop = createTestCoop(courseOffering, s);
-        Company c = createTestCompany();
-        EmployerContact ec = createTestEmployerContact(c);
-        ReportSectionConfig rsConfig = createTestReportSectionConfig();
-        EmployerReport er = createTestEmployerReport(coop, ec);
+        Course course = createTestCourse(courseService);
+        CourseOffering courseOffering = createTestCourseOffering(courseOfferingService, course);
+        Student s = createTestStudent(studentService);
+        Coop coop = createTestCoop(coopService, courseOffering, s);
+        Company c = createTestCompany(companyService);
+        EmployerContact ec = createTestEmployerContact(employerContactService, c);
+        ReportSectionConfig rsConfig =
+                createTestReportSectionConfig(reportConfigService, reportSectionConfigService);
+        EmployerReport er = createTestEmployerReport(employerReportService, coop, ec);
 
         try {
-            rs = employerReportSectionService.createReportSection(response, rsConfig, er);
+            employerReportSectionService.createReportSection(response, rsConfig, er);
 
             employerReportService.deleteEmployerReport(er);
         } catch (IllegalArgumentException e) {
@@ -317,72 +311,5 @@ public class CooperatorServiceEmployerReportSectionTests extends BaseServiceTest
         }
 
         assertEquals(ERROR_PREFIX + "Employer report section to delete cannot be null!", error);
-    }
-
-    private Course createTestCourse() {
-        Course c = null;
-        c = courseService.createCourse("FACC 200");
-        return c;
-    }
-
-    private CourseOffering createTestCourseOffering(Course c) {
-        CourseOffering co = null;
-        co = courseOfferingService.createCourseOffering(2020, Season.WINTER, c);
-        return co;
-    }
-
-    private Coop createTestCoop(CourseOffering co, Student s) {
-        Coop coop = new Coop();
-        coop = coopService.createCoop(CoopStatus.FUTURE, co, s);
-        return coop;
-    }
-
-    private Student createTestStudent() {
-        Student s = new Student();
-        s = studentService.createStudent("Susan", "Matuszewski", "susan@gmail.com", "260719281");
-        return s;
-    }
-
-    private EmployerReport createTestEmployerReport(Coop c, EmployerContact ec) {
-        EmployerReport er = new EmployerReport();
-        File file = new File("src/test/resources/Test_Offer_Letter.pdf");
-        try {
-            MultipartFile multipartFile = new MockMultipartFile("file", new FileInputStream(file));
-
-            er =
-                    employerReportService.createEmployerReport(
-                            ReportStatus.COMPLETED, c, "Offer Letter", ec, multipartFile);
-            return er;
-        } catch (IOException e) {
-            return null;
-        }
-    }
-
-    private ReportSectionConfig createTestReportSectionConfig() {
-        ReportConfig reportConfig =
-                reportConfigService.createReportConfig(true, 14, true, "Evaluation");
-
-        return reportSectionConfigService.createReportSectionConfig(
-                "How was your co-op?", ReportResponseType.LONG_TEXT, reportConfig);
-    }
-
-    private EmployerContact createTestEmployerContact(Company c) {
-        EmployerContact ec;
-        ec =
-                employerContactService.createEmployerContact(
-                        "Albert", "Kragl", "albert@gmail.com", "123456789", c);
-        return ec;
-    }
-
-    private Company createTestCompany() {
-        Company c = new Company();
-        c =
-                companyService.createCompany(
-                        "Facebook",
-                        "Menlo Park",
-                        "California",
-                        "USA",
-                        new ArrayList<EmployerContact>());
-        return c;
     }
 }

--- a/Backend/src/test/java/ca/mcgill/cooperator/service/CooperatorServiceEmployerReportSectionTests.java
+++ b/Backend/src/test/java/ca/mcgill/cooperator/service/CooperatorServiceEmployerReportSectionTests.java
@@ -41,7 +41,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 @SpringBootTest
 @ActiveProfiles("test")
-public class CooperatorServiceEmployerReportSectionTests {
+public class CooperatorServiceEmployerReportSectionTests extends BaseServiceTest {
 
     @Autowired EmployerContactRepository employerContactRepository;
     @Autowired EmployerReportSectionRepository employerReportSectionRepository;
@@ -113,7 +113,8 @@ public class CooperatorServiceEmployerReportSectionTests {
         }
 
         assertEquals(
-                "Response cannot be empty! "
+                ERROR_PREFIX
+                        + "Response cannot be empty! "
                         + "Report section config cannot be null! "
                         + "Employer report cannot be null!",
                 error);
@@ -130,7 +131,8 @@ public class CooperatorServiceEmployerReportSectionTests {
         }
 
         assertEquals(
-                "Response cannot be empty! "
+                ERROR_PREFIX
+                        + "Response cannot be empty! "
                         + "Report section config cannot be null! "
                         + "Employer report cannot be null!",
                 error);
@@ -147,7 +149,8 @@ public class CooperatorServiceEmployerReportSectionTests {
         }
 
         assertEquals(
-                "Response cannot be empty! "
+                ERROR_PREFIX
+                        + "Response cannot be empty! "
                         + "Report section config cannot be null! "
                         + "Employer report cannot be null!",
                 error);
@@ -217,7 +220,10 @@ public class CooperatorServiceEmployerReportSectionTests {
         }
 
         assertEquals(
-                "Employer report section cannot be null! " + "Response cannot be empty!", error);
+                ERROR_PREFIX
+                        + "Employer report section cannot be null! "
+                        + "Response cannot be empty!",
+                error);
     }
 
     @Test
@@ -245,7 +251,7 @@ public class CooperatorServiceEmployerReportSectionTests {
             error = e.getMessage();
         }
 
-        assertEquals("Employer report section cannot be null!", error);
+        assertEquals(ERROR_PREFIX + "Employer report section cannot be null!", error);
     }
 
     @Test
@@ -310,7 +316,7 @@ public class CooperatorServiceEmployerReportSectionTests {
             error = e.getMessage();
         }
 
-        assertEquals("Employer report section to delete cannot be null!", error);
+        assertEquals(ERROR_PREFIX + "Employer report section to delete cannot be null!", error);
     }
 
     private Course createTestCourse() {

--- a/Backend/src/test/java/ca/mcgill/cooperator/service/CooperatorServiceEmployerReportTests.java
+++ b/Backend/src/test/java/ca/mcgill/cooperator/service/CooperatorServiceEmployerReportTests.java
@@ -14,21 +14,16 @@ import ca.mcgill.cooperator.dao.ReportConfigRepository;
 import ca.mcgill.cooperator.dao.StudentRepository;
 import ca.mcgill.cooperator.model.Company;
 import ca.mcgill.cooperator.model.Coop;
-import ca.mcgill.cooperator.model.CoopStatus;
 import ca.mcgill.cooperator.model.Course;
 import ca.mcgill.cooperator.model.CourseOffering;
 import ca.mcgill.cooperator.model.EmployerContact;
 import ca.mcgill.cooperator.model.EmployerReport;
 import ca.mcgill.cooperator.model.EmployerReportSection;
-import ca.mcgill.cooperator.model.ReportConfig;
-import ca.mcgill.cooperator.model.ReportResponseType;
 import ca.mcgill.cooperator.model.ReportSectionConfig;
 import ca.mcgill.cooperator.model.ReportStatus;
-import ca.mcgill.cooperator.model.Season;
 import ca.mcgill.cooperator.model.Student;
 import java.io.File;
 import java.io.FileInputStream;
-import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -97,12 +92,12 @@ public class CooperatorServiceEmployerReportTests extends BaseServiceTest {
 
     @Test
     public void testCreateEmployerReport() {
-        Course course = createTestCourse();
-        CourseOffering courseOffering = createTestCourseOffering(course);
-        Student s = createTestStudent();
-        Coop coop = createTestCoop(courseOffering, s);
-        Company company = createTestCompany();
-        EmployerContact ec = createTestEmployerContact(company);
+        Course course = createTestCourse(courseService);
+        CourseOffering courseOffering = createTestCourseOffering(courseOfferingService, course);
+        Student s = createTestStudent(studentService);
+        Coop coop = createTestCoop(coopService, courseOffering, s);
+        Company company = createTestCompany(companyService);
+        EmployerContact ec = createTestEmployerContact(employerContactService, company);
 
         try {
             MultipartFile multipartFile =
@@ -134,7 +129,8 @@ public class CooperatorServiceEmployerReportTests extends BaseServiceTest {
         }
 
         assertEquals(
-        		ERROR_PREFIX + "Report Status cannot be null! "
+                ERROR_PREFIX
+                        + "Report Status cannot be null! "
                         + "Coop cannot be null! "
                         + "Employer Contact cannot be null! "
                         + "File title cannot be empty!",
@@ -144,14 +140,14 @@ public class CooperatorServiceEmployerReportTests extends BaseServiceTest {
     @Test
     public void testUpdateEmployerReportWithReportSections() {
         EmployerReport er = null;
-
-        Course course = createTestCourse();
-        CourseOffering courseOffering = createTestCourseOffering(course);
-        Student s = createTestStudent();
-        Coop coop = createTestCoop(courseOffering, s);
-        Company company = createTestCompany();
-        EmployerContact ec = createTestEmployerContact(company);
-        ReportSectionConfig rsConfig = createTestReportSectionConfig();
+        Course course = createTestCourse(courseService);
+        CourseOffering courseOffering = createTestCourseOffering(courseOfferingService, course);
+        Student s = createTestStudent(studentService);
+        Coop coop = createTestCoop(coopService, courseOffering, s);
+        Company company = createTestCompany(companyService);
+        EmployerContact ec = createTestEmployerContact(employerContactService, company);
+        ReportSectionConfig rsConfig =
+                createTestReportSectionConfig(reportConfigService, reportSectionConfigService);
 
         MultipartFile multipartFile = null;
         try {
@@ -165,7 +161,8 @@ public class CooperatorServiceEmployerReportTests extends BaseServiceTest {
         }
 
         Set<EmployerReportSection> sections = new HashSet<EmployerReportSection>();
-        EmployerReportSection rs = createTestEmployerReportSection(rsConfig, er);
+        EmployerReportSection rs =
+                createTestEmployerReportSection(employerReportSectionService, rsConfig, er);
         sections.add(rs);
 
         try {
@@ -189,14 +186,14 @@ public class CooperatorServiceEmployerReportTests extends BaseServiceTest {
     @Test
     public void testUpdateEmployerReport() {
         EmployerReport er = null;
-
-        Course course = createTestCourse();
-        CourseOffering courseOffering = createTestCourseOffering(course);
-        Student s = createTestStudent();
-        Coop coop = createTestCoop(courseOffering, s);
-        Company company = createTestCompany();
-        EmployerContact ec = createTestEmployerContact(company);
-        ReportSectionConfig rsConfig = createTestReportSectionConfig();
+        Course course = createTestCourse(courseService);
+        CourseOffering courseOffering = createTestCourseOffering(courseOfferingService, course);
+        Student s = createTestStudent(studentService);
+        Coop coop = createTestCoop(coopService, courseOffering, s);
+        Company company = createTestCompany(companyService);
+        EmployerContact ec = createTestEmployerContact(employerContactService, company);
+        ReportSectionConfig rsConfig =
+                createTestReportSectionConfig(reportConfigService, reportSectionConfigService);
 
         MultipartFile multipartFile = null;
         try {
@@ -210,7 +207,8 @@ public class CooperatorServiceEmployerReportTests extends BaseServiceTest {
         }
 
         Set<EmployerReportSection> sections = new HashSet<EmployerReportSection>();
-        EmployerReportSection rs = createTestEmployerReportSection(rsConfig, er);
+        EmployerReportSection rs =
+                createTestEmployerReportSection(employerReportSectionService, rsConfig, er);
         sections.add(rs);
 
         try {
@@ -239,13 +237,12 @@ public class CooperatorServiceEmployerReportTests extends BaseServiceTest {
     @Test
     public void testUpdateEmployerReportInvalid() {
         EmployerReport er = null;
-
-        Course course = createTestCourse();
-        CourseOffering courseOffering = createTestCourseOffering(course);
-        Student s = createTestStudent();
-        Coop coop = createTestCoop(courseOffering, s);
-        Company company = createTestCompany();
-        EmployerContact ec = createTestEmployerContact(company);
+        Course course = createTestCourse(courseService);
+        CourseOffering courseOffering = createTestCourseOffering(courseOfferingService, course);
+        Student s = createTestStudent(studentService);
+        Coop coop = createTestCoop(coopService, courseOffering, s);
+        Company company = createTestCompany(companyService);
+        EmployerContact ec = createTestEmployerContact(employerContactService, company);
 
         try {
             MultipartFile multipartFile =
@@ -277,12 +274,12 @@ public class CooperatorServiceEmployerReportTests extends BaseServiceTest {
     @Test
     public void testDeleteEmployerReport() {
         EmployerReport er = null;
-        Course course = createTestCourse();
-        CourseOffering courseOffering = createTestCourseOffering(course);
-        Student s = createTestStudent();
-        Coop coop = createTestCoop(courseOffering, s);
-        Company company = createTestCompany();
-        EmployerContact ec = createTestEmployerContact(company);
+        Course course = createTestCourse(courseService);
+        CourseOffering courseOffering = createTestCourseOffering(courseOfferingService, course);
+        Student s = createTestStudent(studentService);
+        Coop coop = createTestCoop(coopService, courseOffering, s);
+        Company company = createTestCompany(companyService);
+        EmployerContact ec = createTestEmployerContact(employerContactService, company);
 
         try {
             MultipartFile multipartFile =
@@ -316,64 +313,5 @@ public class CooperatorServiceEmployerReportTests extends BaseServiceTest {
         }
 
         assertEquals(ERROR_PREFIX + "Employer Report to delete cannot be null!", error);
-    }
-
-    private Course createTestCourse() {
-        Course c = null;
-        c = courseService.createCourse("FACC200");
-        return c;
-    }
-
-    private CourseOffering createTestCourseOffering(Course c) {
-        CourseOffering co = null;
-        co = courseOfferingService.createCourseOffering(2020, Season.WINTER, c);
-        return co;
-    }
-
-    private Coop createTestCoop(CourseOffering co, Student s) {
-        Coop coop = new Coop();
-        coop = coopService.createCoop(CoopStatus.FUTURE, co, s);
-        return coop;
-    }
-
-    private Company createTestCompany() {
-        Company c = new Company();
-        c =
-                companyService.createCompany(
-                        "Facebook",
-                        "Menlo Park",
-                        "California",
-                        "USA",
-                        new ArrayList<EmployerContact>());
-
-        return c;
-    }
-
-    private EmployerContact createTestEmployerContact(Company c) {
-        EmployerContact ec = new EmployerContact();
-        ec =
-                employerContactService.createEmployerContact(
-                        "Emma", "Eags", "eags@gmail.com", "2143546578", c);
-        return ec;
-    }
-
-    private Student createTestStudent() {
-        Student s = new Student();
-        s = studentService.createStudent("Susan", "Matuszewski", "susan@gmail.com", "260719281");
-
-        return s;
-    }
-
-    private EmployerReportSection createTestEmployerReportSection(
-            ReportSectionConfig rsConfig, EmployerReport er) {
-        return employerReportSectionService.createReportSection("This is a response", rsConfig, er);
-    }
-
-    private ReportSectionConfig createTestReportSectionConfig() {
-        ReportConfig reportConfig =
-                reportConfigService.createReportConfig(true, 14, true, "Evaluation");
-
-        return reportSectionConfigService.createReportSectionConfig(
-                "How was your co-op?", ReportResponseType.LONG_TEXT, reportConfig);
     }
 }

--- a/Backend/src/test/java/ca/mcgill/cooperator/service/CooperatorServiceEmployerReportTests.java
+++ b/Backend/src/test/java/ca/mcgill/cooperator/service/CooperatorServiceEmployerReportTests.java
@@ -43,7 +43,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 @SpringBootTest
 @ActiveProfiles("test")
-public class CooperatorServiceEmployerReportTests {
+public class CooperatorServiceEmployerReportTests extends BaseServiceTest {
 
     @Autowired EmployerReportRepository employerReportRepository;
     @Autowired CoopRepository coopRepository;
@@ -134,7 +134,7 @@ public class CooperatorServiceEmployerReportTests {
         }
 
         assertEquals(
-                "Report Status cannot be null! "
+        		ERROR_PREFIX + "Report Status cannot be null! "
                         + "Coop cannot be null! "
                         + "Employer Contact cannot be null! "
                         + "File title cannot be empty!",
@@ -267,7 +267,7 @@ public class CooperatorServiceEmployerReportTests {
             error = e.getMessage();
         }
 
-        assertEquals("Employer Report cannot be null!", error);
+        assertEquals(ERROR_PREFIX + "Employer Report cannot be null!", error);
         assertEquals(
                 ReportStatus.COMPLETED,
                 employerReportService.getEmployerReport(er.getId()).getStatus());
@@ -315,7 +315,7 @@ public class CooperatorServiceEmployerReportTests {
             error = e.getMessage();
         }
 
-        assertEquals("Employer Report to delete cannot be null!", error);
+        assertEquals(ERROR_PREFIX + "Employer Report to delete cannot be null!", error);
     }
 
     private Course createTestCourse() {

--- a/Backend/src/test/java/ca/mcgill/cooperator/service/CooperatorServiceNotificationTests.java
+++ b/Backend/src/test/java/ca/mcgill/cooperator/service/CooperatorServiceNotificationTests.java
@@ -42,8 +42,8 @@ public class CooperatorServiceNotificationTests extends BaseServiceTest {
     public void testCreateNotification() {
         String title = "Hello";
         String body = "Please attend meeting.";
-        Student student = createTestStudent();
-        Admin sender = createTestAdmin();
+        Student student = createTestStudent(studentService);
+        Admin sender = createTestAdmin(adminService);
 
         try {
             notificationService.createNotification(title, body, student, sender);
@@ -63,8 +63,8 @@ public class CooperatorServiceNotificationTests extends BaseServiceTest {
     public void testCreateNotificationSetSeen() {
         String title = "Hello";
         String body = "Please attend meeting.";
-        Student student = createTestStudent();
-        Admin sender = createTestAdmin();
+        Student student = createTestStudent(studentService);
+        Admin sender = createTestAdmin(adminService);
 
         try {
             notificationService.createNotification(title, body, student, sender);
@@ -103,7 +103,8 @@ public class CooperatorServiceNotificationTests extends BaseServiceTest {
         }
 
         assertEquals(
-        		ERROR_PREFIX + "Notification title cannot be empty! "
+                ERROR_PREFIX
+                        + "Notification title cannot be empty! "
                         + "Notification body cannot be empty! "
                         + "Notification must have a Student receiver! "
                         + "Notification must have an Admin sender!",
@@ -127,7 +128,8 @@ public class CooperatorServiceNotificationTests extends BaseServiceTest {
         }
 
         assertEquals(
-        		ERROR_PREFIX + "Notification title cannot be empty! "
+                ERROR_PREFIX
+                        + "Notification title cannot be empty! "
                         + "Notification body cannot be empty! "
                         + "Notification must have a Student receiver! "
                         + "Notification must have an Admin sender!",
@@ -151,7 +153,8 @@ public class CooperatorServiceNotificationTests extends BaseServiceTest {
         }
 
         assertEquals(
-        		ERROR_PREFIX + "Notification title cannot be empty! "
+                ERROR_PREFIX
+                        + "Notification title cannot be empty! "
                         + "Notification body cannot be empty! "
                         + "Notification must have a Student receiver! "
                         + "Notification must have an Admin sender!",
@@ -163,8 +166,8 @@ public class CooperatorServiceNotificationTests extends BaseServiceTest {
     public void testUpdateNotification() {
         String title = "Hello";
         String body = "Please attend meeting.";
-        Student student = createTestStudent();
-        Admin sender = createTestAdmin();
+        Student student = createTestStudent(studentService);
+        Admin sender = createTestAdmin(adminService);
 
         Notification n = null;
 
@@ -194,8 +197,8 @@ public class CooperatorServiceNotificationTests extends BaseServiceTest {
     public void testUpdateNotificationInvalid() {
         String title = "Hello";
         String body = "Please attend meeting.";
-        Student student = createTestStudent();
-        Admin sender = createTestAdmin();
+        Student student = createTestStudent(studentService);
+        Admin sender = createTestAdmin(adminService);
 
         Notification n = null;
 
@@ -210,7 +213,8 @@ public class CooperatorServiceNotificationTests extends BaseServiceTest {
         } catch (IllegalArgumentException e) {
             String error = e.getMessage();
             assertEquals(
-            		ERROR_PREFIX + "Notification title cannot be empty! "
+                    ERROR_PREFIX
+                            + "Notification title cannot be empty! "
                             + "Notification body cannot be empty! "
                             + "Notification must have a Student receiver! "
                             + "Notification must have an Admin sender!",
@@ -222,8 +226,8 @@ public class CooperatorServiceNotificationTests extends BaseServiceTest {
     public void testDeleteNotification() {
         String title = "Hello";
         String body = "Please attend meeting.";
-        Student student = createTestStudent();
-        Admin sender = createTestAdmin();
+        Student student = createTestStudent(studentService);
+        Admin sender = createTestAdmin(adminService);
 
         Notification n = null;
 
@@ -238,19 +242,5 @@ public class CooperatorServiceNotificationTests extends BaseServiceTest {
         }
 
         assertEquals(0, notificationService.getAllNotifications().size());
-    }
-
-    public Student createTestStudent() {
-        Student s = new Student();
-        s = studentService.createStudent("Susan", "Matuszewski", "susan@gmail.com", "260719281");
-
-        return s;
-    }
-
-    public Admin createTestAdmin() {
-        Admin a = new Admin();
-        a = adminService.createAdmin("Lorraine", "Douglas", "lorraine@gmail.com");
-
-        return a;
     }
 }

--- a/Backend/src/test/java/ca/mcgill/cooperator/service/CooperatorServiceNotificationTests.java
+++ b/Backend/src/test/java/ca/mcgill/cooperator/service/CooperatorServiceNotificationTests.java
@@ -20,7 +20,7 @@ import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
 @ActiveProfiles("test")
-public class CooperatorServiceNotificationTests {
+public class CooperatorServiceNotificationTests extends BaseServiceTest {
 
     @Autowired NotificationService notificationService;
     @Autowired AdminService adminService;
@@ -34,7 +34,6 @@ public class CooperatorServiceNotificationTests {
     @AfterEach
     public void clearDatabase() {
         notificationRepository.deleteAll();
-
         studentRepository.deleteAll();
         adminRepository.deleteAll();
     }
@@ -104,7 +103,7 @@ public class CooperatorServiceNotificationTests {
         }
 
         assertEquals(
-                "Notification title cannot be empty! "
+        		ERROR_PREFIX + "Notification title cannot be empty! "
                         + "Notification body cannot be empty! "
                         + "Notification must have a Student receiver! "
                         + "Notification must have an Admin sender!",
@@ -128,7 +127,7 @@ public class CooperatorServiceNotificationTests {
         }
 
         assertEquals(
-                "Notification title cannot be empty! "
+        		ERROR_PREFIX + "Notification title cannot be empty! "
                         + "Notification body cannot be empty! "
                         + "Notification must have a Student receiver! "
                         + "Notification must have an Admin sender!",
@@ -152,7 +151,7 @@ public class CooperatorServiceNotificationTests {
         }
 
         assertEquals(
-                "Notification title cannot be empty! "
+        		ERROR_PREFIX + "Notification title cannot be empty! "
                         + "Notification body cannot be empty! "
                         + "Notification must have a Student receiver! "
                         + "Notification must have an Admin sender!",
@@ -211,7 +210,7 @@ public class CooperatorServiceNotificationTests {
         } catch (IllegalArgumentException e) {
             String error = e.getMessage();
             assertEquals(
-                    "Notification title cannot be empty! "
+            		ERROR_PREFIX + "Notification title cannot be empty! "
                             + "Notification body cannot be empty! "
                             + "Notification must have a Student receiver! "
                             + "Notification must have an Admin sender!",

--- a/Backend/src/test/java/ca/mcgill/cooperator/service/CooperatorServiceStudentReportSectionTests.java
+++ b/Backend/src/test/java/ca/mcgill/cooperator/service/CooperatorServiceStudentReportSectionTests.java
@@ -11,34 +11,24 @@ import ca.mcgill.cooperator.dao.StudentReportRepository;
 import ca.mcgill.cooperator.dao.StudentReportSectionRepository;
 import ca.mcgill.cooperator.dao.StudentRepository;
 import ca.mcgill.cooperator.model.Coop;
-import ca.mcgill.cooperator.model.CoopStatus;
 import ca.mcgill.cooperator.model.Course;
 import ca.mcgill.cooperator.model.CourseOffering;
-import ca.mcgill.cooperator.model.ReportConfig;
-import ca.mcgill.cooperator.model.ReportResponseType;
 import ca.mcgill.cooperator.model.ReportSectionConfig;
-import ca.mcgill.cooperator.model.ReportStatus;
-import ca.mcgill.cooperator.model.Season;
 import ca.mcgill.cooperator.model.Student;
 import ca.mcgill.cooperator.model.StudentReport;
 import ca.mcgill.cooperator.model.StudentReportSection;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
 import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.web.multipart.MultipartFile;
 
 @SpringBootTest
 @ActiveProfiles("test")
 public class CooperatorServiceStudentReportSectionTests extends BaseServiceTest {
-	
+
     @Autowired StudentReportSectionRepository studentReportSectionRepository;
     @Autowired StudentReportRepository studentReportRepository;
     @Autowired CoopRepository coopRepository;
@@ -77,12 +67,13 @@ public class CooperatorServiceStudentReportSectionTests extends BaseServiceTest 
     @Test
     public void createReportSection() {
         String response = "This is a response";
-        Course course = createTestCourse();
-        CourseOffering courseOffering = createTestCourseOffering(course);
-        Student s = createTestStudent();
-        Coop coop = createTestCoop(courseOffering, s);
-        StudentReport sr = createTestStudentReport(coop);
-        ReportSectionConfig rsConfig = createTestReportSectionConfig();
+        Course course = createTestCourse(courseService);
+        CourseOffering courseOffering = createTestCourseOffering(courseOfferingService, course);
+        Student s = createTestStudent(studentService);
+        Coop coop = createTestCoop(coopService, courseOffering, s);
+        StudentReport sr = createTestStudentReport(studentReportService, coop);
+        ReportSectionConfig rsConfig =
+                createTestReportSectionConfig(reportConfigService, reportSectionConfigService);
 
         try {
             studentReportSectionService.createReportSection(response, rsConfig, sr);
@@ -103,7 +94,8 @@ public class CooperatorServiceStudentReportSectionTests extends BaseServiceTest 
         }
 
         assertEquals(
-        		ERROR_PREFIX + "Response cannot be empty! "
+                ERROR_PREFIX
+                        + "Response cannot be empty! "
                         + "Report section config cannot be null! "
                         + "Student report cannot be null!",
                 error);
@@ -120,7 +112,8 @@ public class CooperatorServiceStudentReportSectionTests extends BaseServiceTest 
         }
 
         assertEquals(
-        		ERROR_PREFIX + "Response cannot be empty! "
+                ERROR_PREFIX
+                        + "Response cannot be empty! "
                         + "Report section config cannot be null! "
                         + "Student report cannot be null!",
                 error);
@@ -137,7 +130,8 @@ public class CooperatorServiceStudentReportSectionTests extends BaseServiceTest 
         }
 
         assertEquals(
-        		ERROR_PREFIX + "Response cannot be empty! "
+                ERROR_PREFIX
+                        + "Response cannot be empty! "
                         + "Report section config cannot be null! "
                         + "Student report cannot be null!",
                 error);
@@ -148,12 +142,13 @@ public class CooperatorServiceStudentReportSectionTests extends BaseServiceTest 
     public void updateReportSection() {
         StudentReportSection rs = null;
         String response = "This is a response";
-        Course course = createTestCourse();
-        CourseOffering courseOffering = createTestCourseOffering(course);
-        Student s = createTestStudent();
-        Coop coop = createTestCoop(courseOffering, s);
-        StudentReport sr = createTestStudentReport(coop);
-        ReportSectionConfig rsConfig = createTestReportSectionConfig();
+        Course course = createTestCourse(courseService);
+        CourseOffering courseOffering = createTestCourseOffering(courseOfferingService, course);
+        Student s = createTestStudent(studentService);
+        Coop coop = createTestCoop(coopService, courseOffering, s);
+        StudentReport sr = createTestStudentReport(studentReportService, coop);
+        ReportSectionConfig rsConfig =
+                createTestReportSectionConfig(reportConfigService, reportSectionConfigService);
 
         try {
             rs = studentReportSectionService.createReportSection(response, rsConfig, sr);
@@ -184,12 +179,13 @@ public class CooperatorServiceStudentReportSectionTests extends BaseServiceTest 
     public void updateReportSectionInvalid() {
         StudentReportSection rs = null;
         String response = "This is a response";
-        Course course = createTestCourse();
-        CourseOffering courseOffering = createTestCourseOffering(course);
-        Student s = createTestStudent();
-        Coop coop = createTestCoop(courseOffering, s);
-        StudentReport sr = createTestStudentReport(coop);
-        ReportSectionConfig rsConfig = createTestReportSectionConfig();
+        Course course = createTestCourse(courseService);
+        CourseOffering courseOffering = createTestCourseOffering(courseOfferingService, course);
+        Student s = createTestStudent(studentService);
+        Coop coop = createTestCoop(coopService, courseOffering, s);
+        StudentReport sr = createTestStudentReport(studentReportService, coop);
+        ReportSectionConfig rsConfig =
+                createTestReportSectionConfig(reportConfigService, reportSectionConfigService);
 
         try {
             studentReportSectionService.createReportSection(response, rsConfig, sr);
@@ -207,18 +203,22 @@ public class CooperatorServiceStudentReportSectionTests extends BaseServiceTest 
         }
 
         assertEquals(
-        		ERROR_PREFIX + "Student report section cannot be null! " + "Response cannot be empty!", error);
+                ERROR_PREFIX
+                        + "Student report section cannot be null! "
+                        + "Response cannot be empty!",
+                error);
     }
 
     @Test
     public void updateReportSectionNull() {
         String response = "This is a response";
-        Course course = createTestCourse();
-        CourseOffering courseOffering = createTestCourseOffering(course);
-        Student s = createTestStudent();
-        Coop coop = createTestCoop(courseOffering, s);
-        StudentReport sr = createTestStudentReport(coop);
-        ReportSectionConfig rsConfig = createTestReportSectionConfig();
+        Course course = createTestCourse(courseService);
+        CourseOffering courseOffering = createTestCourseOffering(courseOfferingService, course);
+        Student s = createTestStudent(studentService);
+        Coop coop = createTestCoop(coopService, courseOffering, s);
+        StudentReport sr = createTestStudentReport(studentReportService, coop);
+        ReportSectionConfig rsConfig =
+                createTestReportSectionConfig(reportConfigService, reportSectionConfigService);
 
         try {
             studentReportSectionService.createReportSection(response, rsConfig, sr);
@@ -242,12 +242,13 @@ public class CooperatorServiceStudentReportSectionTests extends BaseServiceTest 
     public void deleteReportSection() {
         StudentReportSection rs = null;
         String response = "This is a response";
-        Course course = createTestCourse();
-        CourseOffering courseOffering = createTestCourseOffering(course);
-        Student s = createTestStudent();
-        Coop coop = createTestCoop(courseOffering, s);
-        StudentReport sr = createTestStudentReport(coop);
-        ReportSectionConfig rsConfig = createTestReportSectionConfig();
+        Course course = createTestCourse(courseService);
+        CourseOffering courseOffering = createTestCourseOffering(courseOfferingService, course);
+        Student s = createTestStudent(studentService);
+        Coop coop = createTestCoop(coopService, courseOffering, s);
+        StudentReport sr = createTestStudentReport(studentReportService, coop);
+        ReportSectionConfig rsConfig =
+                createTestReportSectionConfig(reportConfigService, reportSectionConfigService);
 
         try {
             rs = studentReportSectionService.createReportSection(response, rsConfig, sr);
@@ -270,12 +271,13 @@ public class CooperatorServiceStudentReportSectionTests extends BaseServiceTest 
     public void deleteReportSectionStudentReport() {
         StudentReportSection rs = null;
         String response = "This is a response";
-        Course course = createTestCourse();
-        CourseOffering courseOffering = createTestCourseOffering(course);
-        Student s = createTestStudent();
-        Coop coop = createTestCoop(courseOffering, s);
-        StudentReport sr = createTestStudentReport(coop);
-        ReportSectionConfig rsConfig = createTestReportSectionConfig();
+        Course course = createTestCourse(courseService);
+        CourseOffering courseOffering = createTestCourseOffering(courseOfferingService, course);
+        Student s = createTestStudent(studentService);
+        Coop coop = createTestCoop(coopService, courseOffering, s);
+        StudentReport sr = createTestStudentReport(studentReportService, coop);
+        ReportSectionConfig rsConfig =
+                createTestReportSectionConfig(reportConfigService, reportSectionConfigService);
 
         try {
             rs = studentReportSectionService.createReportSection(response, rsConfig, sr);
@@ -299,52 +301,5 @@ public class CooperatorServiceStudentReportSectionTests extends BaseServiceTest 
         }
 
         assertEquals(ERROR_PREFIX + "Student report section to delete cannot be null!", error);
-    }
-
-    private Course createTestCourse() {
-        Course c = null;
-        c = courseService.createCourse("FACC 200");
-        return c;
-    }
-
-    private CourseOffering createTestCourseOffering(Course c) {
-        CourseOffering co = null;
-        co = courseOfferingService.createCourseOffering(2020, Season.WINTER, c);
-        return co;
-    }
-
-    private Coop createTestCoop(CourseOffering co, Student s) {
-        Coop coop = new Coop();
-        coop = coopService.createCoop(CoopStatus.FUTURE, co, s);
-        return coop;
-    }
-
-    private Student createTestStudent() {
-        Student s = new Student();
-        s = studentService.createStudent("Susan", "Matuszewski", "susan@gmail.com", "260719281");
-        return s;
-    }
-
-    private StudentReport createTestStudentReport(Coop c) {
-        StudentReport sr = new StudentReport();
-        File file = new File("src/test/resources/Test_Offer_Letter.pdf");
-        try {
-            MultipartFile multipartFile = new MockMultipartFile("file", new FileInputStream(file));
-
-            sr =
-                    studentReportService.createStudentReport(
-                            ReportStatus.COMPLETED, c, "Offer Letter", multipartFile);
-            return sr;
-        } catch (IOException e) {
-            return null;
-        }
-    }
-
-    private ReportSectionConfig createTestReportSectionConfig() {
-        ReportConfig reportConfig =
-                reportConfigService.createReportConfig(true, 14, true, "Evaluation");
-
-        return reportSectionConfigService.createReportSectionConfig(
-                "How was your co-op?", ReportResponseType.LONG_TEXT, reportConfig);
     }
 }

--- a/Backend/src/test/java/ca/mcgill/cooperator/service/CooperatorServiceStudentReportSectionTests.java
+++ b/Backend/src/test/java/ca/mcgill/cooperator/service/CooperatorServiceStudentReportSectionTests.java
@@ -37,7 +37,8 @@ import org.springframework.web.multipart.MultipartFile;
 
 @SpringBootTest
 @ActiveProfiles("test")
-public class CooperatorServiceStudentReportSectionTests {
+public class CooperatorServiceStudentReportSectionTests extends BaseServiceTest {
+	
     @Autowired StudentReportSectionRepository studentReportSectionRepository;
     @Autowired StudentReportRepository studentReportRepository;
     @Autowired CoopRepository coopRepository;
@@ -102,7 +103,7 @@ public class CooperatorServiceStudentReportSectionTests {
         }
 
         assertEquals(
-                "Response cannot be empty! "
+        		ERROR_PREFIX + "Response cannot be empty! "
                         + "Report section config cannot be null! "
                         + "Student report cannot be null!",
                 error);
@@ -119,7 +120,7 @@ public class CooperatorServiceStudentReportSectionTests {
         }
 
         assertEquals(
-                "Response cannot be empty! "
+        		ERROR_PREFIX + "Response cannot be empty! "
                         + "Report section config cannot be null! "
                         + "Student report cannot be null!",
                 error);
@@ -136,7 +137,7 @@ public class CooperatorServiceStudentReportSectionTests {
         }
 
         assertEquals(
-                "Response cannot be empty! "
+        		ERROR_PREFIX + "Response cannot be empty! "
                         + "Report section config cannot be null! "
                         + "Student report cannot be null!",
                 error);
@@ -206,7 +207,7 @@ public class CooperatorServiceStudentReportSectionTests {
         }
 
         assertEquals(
-                "Student report section cannot be null! " + "Response cannot be empty!", error);
+        		ERROR_PREFIX + "Student report section cannot be null! " + "Response cannot be empty!", error);
     }
 
     @Test
@@ -234,7 +235,7 @@ public class CooperatorServiceStudentReportSectionTests {
             error = e.getMessage();
         }
 
-        assertEquals("Student report section cannot be null!", error);
+        assertEquals(ERROR_PREFIX + "Student report section cannot be null!", error);
     }
 
     @Test
@@ -297,7 +298,7 @@ public class CooperatorServiceStudentReportSectionTests {
             error = e.getMessage();
         }
 
-        assertEquals("Student report section to delete cannot be null!", error);
+        assertEquals(ERROR_PREFIX + "Student report section to delete cannot be null!", error);
     }
 
     private Course createTestCourse() {

--- a/Backend/src/test/java/ca/mcgill/cooperator/service/CooperatorServiceStudentReportTests.java
+++ b/Backend/src/test/java/ca/mcgill/cooperator/service/CooperatorServiceStudentReportTests.java
@@ -38,7 +38,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 @SpringBootTest
 @ActiveProfiles("test")
-public class CooperatorServiceStudentReportTests {
+public class CooperatorServiceStudentReportTests extends BaseServiceTest {
     @Autowired StudentReportRepository studentReportRepository;
     @Autowired CoopRepository coopRepository;
     @Autowired CourseRepository courseRepository;
@@ -109,7 +109,7 @@ public class CooperatorServiceStudentReportTests {
         }
 
         assertEquals(
-                "Report Status cannot be null! "
+        		ERROR_PREFIX + "Report Status cannot be null! "
                         + "Coop cannot be null! "
                         + "File title cannot be empty!",
                 error);
@@ -241,7 +241,7 @@ public class CooperatorServiceStudentReportTests {
             error = e.getMessage();
         }
 
-        assertEquals("Student Report cannot be null!", error);
+        assertEquals(ERROR_PREFIX + "Student Report cannot be null!", error);
         assertEquals(
                 ReportStatus.COMPLETED,
                 studentReportService.getStudentReport(sr.getId()).getStatus());
@@ -289,7 +289,7 @@ public class CooperatorServiceStudentReportTests {
             error = e.getMessage();
         }
 
-        assertEquals("Student Report to delete cannot be null!", error);
+        assertEquals(ERROR_PREFIX + "Student Report to delete cannot be null!", error);
     }
 
     private Course createTestCourse() {

--- a/Backend/src/test/java/ca/mcgill/cooperator/service/CooperatorServiceStudentReportTests.java
+++ b/Backend/src/test/java/ca/mcgill/cooperator/service/CooperatorServiceStudentReportTests.java
@@ -11,14 +11,10 @@ import ca.mcgill.cooperator.dao.StudentReportRepository;
 import ca.mcgill.cooperator.dao.StudentReportSectionRepository;
 import ca.mcgill.cooperator.dao.StudentRepository;
 import ca.mcgill.cooperator.model.Coop;
-import ca.mcgill.cooperator.model.CoopStatus;
 import ca.mcgill.cooperator.model.Course;
 import ca.mcgill.cooperator.model.CourseOffering;
-import ca.mcgill.cooperator.model.ReportConfig;
-import ca.mcgill.cooperator.model.ReportResponseType;
 import ca.mcgill.cooperator.model.ReportSectionConfig;
 import ca.mcgill.cooperator.model.ReportStatus;
-import ca.mcgill.cooperator.model.Season;
 import ca.mcgill.cooperator.model.Student;
 import ca.mcgill.cooperator.model.StudentReport;
 import ca.mcgill.cooperator.model.StudentReportSection;
@@ -78,10 +74,10 @@ public class CooperatorServiceStudentReportTests extends BaseServiceTest {
 
     @Test
     public void testCreateStudentReport() {
-        Course course = createTestCourse();
-        CourseOffering courseOffering = createTestCourseOffering(course);
-        Student s = createTestStudent();
-        Coop coop = createTestCoop(courseOffering, s);
+        Course course = createTestCourse(courseService);
+        CourseOffering courseOffering = createTestCourseOffering(courseOfferingService, course);
+        Student s = createTestStudent(studentService);
+        Coop coop = createTestCoop(coopService, courseOffering, s);
 
         try {
             MultipartFile multipartFile =
@@ -109,7 +105,8 @@ public class CooperatorServiceStudentReportTests extends BaseServiceTest {
         }
 
         assertEquals(
-        		ERROR_PREFIX + "Report Status cannot be null! "
+                ERROR_PREFIX
+                        + "Report Status cannot be null! "
                         + "Coop cannot be null! "
                         + "File title cannot be empty!",
                 error);
@@ -120,11 +117,12 @@ public class CooperatorServiceStudentReportTests extends BaseServiceTest {
     public void testUpdateStudentReportWithReportSections() {
         StudentReport sr = null;
 
-        Course course = createTestCourse();
-        CourseOffering courseOffering = createTestCourseOffering(course);
-        Student s = createTestStudent();
-        Coop coop = createTestCoop(courseOffering, s);
-        ReportSectionConfig rsConfig = createTestReportSectionConfig();
+        Course course = createTestCourse(courseService);
+        CourseOffering courseOffering = createTestCourseOffering(courseOfferingService, course);
+        Student s = createTestStudent(studentService);
+        Coop coop = createTestCoop(coopService, courseOffering, s);
+        ReportSectionConfig rsConfig =
+                createTestReportSectionConfig(reportConfigService, reportSectionConfigService);
 
         // 1. create Student Report
         MultipartFile multipartFile = null;
@@ -139,7 +137,8 @@ public class CooperatorServiceStudentReportTests extends BaseServiceTest {
         }
 
         Set<StudentReportSection> sections = new HashSet<StudentReportSection>();
-        StudentReportSection rs = createTestStudentReportSection(rsConfig, sr);
+        StudentReportSection rs =
+                createTestStudentReportSection(studentReportSectionService, rsConfig, sr);
         sections.add(rs);
 
         // 2. update with valid values
@@ -169,11 +168,12 @@ public class CooperatorServiceStudentReportTests extends BaseServiceTest {
     public void testUpdateStudentReport() {
         StudentReport sr = null;
 
-        Course course = createTestCourse();
-        CourseOffering courseOffering = createTestCourseOffering(course);
-        Student s = createTestStudent();
-        Coop coop = createTestCoop(courseOffering, s);
-        ReportSectionConfig rsConfig = createTestReportSectionConfig();
+        Course course = createTestCourse(courseService);
+        CourseOffering courseOffering = createTestCourseOffering(courseOfferingService, course);
+        Student s = createTestStudent(studentService);
+        Coop coop = createTestCoop(coopService, courseOffering, s);
+        ReportSectionConfig rsConfig =
+                createTestReportSectionConfig(reportConfigService, reportSectionConfigService);
 
         // 1. create Student Report
         MultipartFile multipartFile = null;
@@ -188,7 +188,8 @@ public class CooperatorServiceStudentReportTests extends BaseServiceTest {
         }
 
         Set<StudentReportSection> sections = new HashSet<StudentReportSection>();
-        StudentReportSection rs = createTestStudentReportSection(rsConfig, sr);
+        StudentReportSection rs =
+                createTestStudentReportSection(studentReportSectionService, rsConfig, sr);
         sections.add(rs);
 
         // 2. update with valid values
@@ -215,11 +216,10 @@ public class CooperatorServiceStudentReportTests extends BaseServiceTest {
     @Test
     public void testUpdateStudentReportInvalid() {
         StudentReport sr = null;
-
-        Course course = createTestCourse();
-        CourseOffering courseOffering = createTestCourseOffering(course);
-        Student s = createTestStudent();
-        Coop coop = createTestCoop(courseOffering, s);
+        Course course = createTestCourse(courseService);
+        CourseOffering courseOffering = createTestCourseOffering(courseOfferingService, course);
+        Student s = createTestStudent(studentService);
+        Coop coop = createTestCoop(coopService, courseOffering, s);
 
         // 1. create Student Report
         MultipartFile multipartFile = null;
@@ -251,10 +251,10 @@ public class CooperatorServiceStudentReportTests extends BaseServiceTest {
     @Test
     public void testDeleteStudentReport() {
         StudentReport sr = null;
-        Course course = createTestCourse();
-        CourseOffering courseOffering = createTestCourseOffering(course);
-        Student s = createTestStudent();
-        Coop coop = createTestCoop(courseOffering, s);
+        Course course = createTestCourse(courseService);
+        CourseOffering courseOffering = createTestCourseOffering(courseOfferingService, course);
+        Student s = createTestStudent(studentService);
+        Coop coop = createTestCoop(coopService, courseOffering, s);
 
         // 1. create Student Report
         try {
@@ -290,43 +290,5 @@ public class CooperatorServiceStudentReportTests extends BaseServiceTest {
         }
 
         assertEquals(ERROR_PREFIX + "Student Report to delete cannot be null!", error);
-    }
-
-    private Course createTestCourse() {
-        Course c = null;
-        c = courseService.createCourse("FACC200");
-        return c;
-    }
-
-    private CourseOffering createTestCourseOffering(Course c) {
-        CourseOffering co = null;
-        co = courseOfferingService.createCourseOffering(2020, Season.WINTER, c);
-        return co;
-    }
-
-    private Coop createTestCoop(CourseOffering co, Student s) {
-        Coop coop = new Coop();
-        coop = coopService.createCoop(CoopStatus.FUTURE, co, s);
-        return coop;
-    }
-
-    private Student createTestStudent() {
-        Student s = new Student();
-        s = studentService.createStudent("Susan", "Matuszewski", "susan@gmail.com", "260719281");
-
-        return s;
-    }
-
-    private StudentReportSection createTestStudentReportSection(
-            ReportSectionConfig rsConfig, StudentReport sr) {
-        return studentReportSectionService.createReportSection("This is a response", rsConfig, sr);
-    }
-
-    private ReportSectionConfig createTestReportSectionConfig() {
-        ReportConfig reportConfig =
-                reportConfigService.createReportConfig(true, 14, true, "Evaluation");
-
-        return reportSectionConfigService.createReportSectionConfig(
-                "How was your co-op?", ReportResponseType.LONG_TEXT, reportConfig);
     }
 }

--- a/Backend/src/test/java/ca/mcgill/cooperator/service/CooperatorServiceStudentTests.java
+++ b/Backend/src/test/java/ca/mcgill/cooperator/service/CooperatorServiceStudentTests.java
@@ -11,11 +11,9 @@ import ca.mcgill.cooperator.dao.NotificationRepository;
 import ca.mcgill.cooperator.dao.StudentRepository;
 import ca.mcgill.cooperator.model.Admin;
 import ca.mcgill.cooperator.model.Coop;
-import ca.mcgill.cooperator.model.CoopStatus;
 import ca.mcgill.cooperator.model.Course;
 import ca.mcgill.cooperator.model.CourseOffering;
 import ca.mcgill.cooperator.model.Notification;
-import ca.mcgill.cooperator.model.Season;
 import ca.mcgill.cooperator.model.Student;
 import java.util.HashSet;
 import java.util.Set;
@@ -106,7 +104,8 @@ public class CooperatorServiceStudentTests extends BaseServiceTest {
         }
 
         assertEquals(
-        		ERROR_PREFIX + "Student first name cannot be empty. "
+                ERROR_PREFIX
+                        + "Student first name cannot be empty. "
                         + "Student last name cannot be empty. "
                         + "Student email cannot be empty. "
                         + "Student ID cannot be null or invalid.",
@@ -123,7 +122,8 @@ public class CooperatorServiceStudentTests extends BaseServiceTest {
         }
 
         assertEquals(
-        		ERROR_PREFIX + "Student first name cannot be empty. "
+                ERROR_PREFIX
+                        + "Student first name cannot be empty. "
                         + "Student last name cannot be empty. "
                         + "Student email cannot be empty. "
                         + "Student ID cannot be null or invalid.",
@@ -140,7 +140,8 @@ public class CooperatorServiceStudentTests extends BaseServiceTest {
         }
 
         assertEquals(
-        		ERROR_PREFIX + "Student first name cannot be empty. "
+                ERROR_PREFIX
+                        + "Student first name cannot be empty. "
                         + "Student last name cannot be empty. "
                         + "Student email cannot be empty. "
                         + "Student ID cannot be null or invalid.",
@@ -196,13 +197,13 @@ public class CooperatorServiceStudentTests extends BaseServiceTest {
 
         assertEquals(1, studentService.getAllStudents().size());
 
-        Course course = createTestCourse();
-        CourseOffering courseOffering = createTestCourseOffering(course);
-        Coop coop = createTestCoop(courseOffering, s);
+        Course course = createTestCourse(courseService);
+        CourseOffering courseOffering = createTestCourseOffering(courseOfferingService, course);
+        Coop coop = createTestCoop(coopService, courseOffering, s);
         Set<Coop> coops = new HashSet<Coop>();
         coops.add(coop);
-        Admin a = createTestAdmin();
-        Notification notif = createTestNotification(s, a);
+        Admin a = createTestAdmin(adminService);
+        Notification notif = createTestNotification(notificationService, s, a);
         Set<Notification> notifs = new HashSet<Notification>();
         notifs.add(notif);
 
@@ -318,13 +319,13 @@ public class CooperatorServiceStudentTests extends BaseServiceTest {
 
         assertEquals(1, studentService.getAllStudents().size());
 
-        Course course = createTestCourse();
-        CourseOffering courseOffering = createTestCourseOffering(course);
-        Coop coop = createTestCoop(courseOffering, s);
+        Course course = createTestCourse(courseService);
+        CourseOffering courseOffering = createTestCourseOffering(courseOfferingService, course);
+        Coop coop = createTestCoop(coopService, courseOffering, s);
         Set<Coop> coops = new HashSet<Coop>();
         coops.add(coop);
-        Admin a = createTestAdmin();
-        Notification notif = createTestNotification(s, a);
+        Admin a = createTestAdmin(adminService);
+        Notification notif = createTestNotification(notificationService, s, a);
         Set<Notification> notifs = new HashSet<Notification>();
         notifs.add(notif);
 
@@ -343,35 +344,5 @@ public class CooperatorServiceStudentTests extends BaseServiceTest {
         }
 
         assertEquals(0, studentService.getAllStudents().size());
-    }
-
-    private Course createTestCourse() {
-        Course c = null;
-        c = courseService.createCourse("FACC200");
-        return c;
-    }
-
-    private CourseOffering createTestCourseOffering(Course c) {
-        CourseOffering co = null;
-        co = courseOfferingService.createCourseOffering(2020, Season.WINTER, c);
-        return co;
-    }
-
-    private Coop createTestCoop(CourseOffering co, Student s) {
-        Coop coop = new Coop();
-        coop = coopService.createCoop(CoopStatus.FUTURE, co, s);
-        return coop;
-    }
-
-    private Admin createTestAdmin() {
-        Admin a = new Admin();
-        a = adminService.createAdmin("Emma", "Eagles", "emma@gmail.com");
-        return a;
-    }
-
-    private Notification createTestNotification(Student s, Admin a) {
-        Notification notif = new Notification();
-        notif = notificationService.createNotification("title", "body", s, a);
-        return notif;
     }
 }

--- a/Backend/src/test/java/ca/mcgill/cooperator/service/CooperatorServiceStudentTests.java
+++ b/Backend/src/test/java/ca/mcgill/cooperator/service/CooperatorServiceStudentTests.java
@@ -28,7 +28,7 @@ import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
 @ActiveProfiles("test")
-public class CooperatorServiceStudentTests {
+public class CooperatorServiceStudentTests extends BaseServiceTest {
 
     @Autowired StudentService studentService;
     @Autowired CourseService courseService;
@@ -106,7 +106,7 @@ public class CooperatorServiceStudentTests {
         }
 
         assertEquals(
-                "Student first name cannot be empty. "
+        		ERROR_PREFIX + "Student first name cannot be empty. "
                         + "Student last name cannot be empty. "
                         + "Student email cannot be empty. "
                         + "Student ID cannot be null or invalid.",
@@ -123,7 +123,7 @@ public class CooperatorServiceStudentTests {
         }
 
         assertEquals(
-                "Student first name cannot be empty. "
+        		ERROR_PREFIX + "Student first name cannot be empty. "
                         + "Student last name cannot be empty. "
                         + "Student email cannot be empty. "
                         + "Student ID cannot be null or invalid.",
@@ -140,7 +140,7 @@ public class CooperatorServiceStudentTests {
         }
 
         assertEquals(
-                "Student first name cannot be empty. "
+        		ERROR_PREFIX + "Student first name cannot be empty. "
                         + "Student last name cannot be empty. "
                         + "Student email cannot be empty. "
                         + "Student ID cannot be null or invalid.",
@@ -272,7 +272,7 @@ public class CooperatorServiceStudentTests {
             error = e.getMessage();
         }
 
-        assertEquals("Student to update cannot be null.", error);
+        assertEquals(ERROR_PREFIX + "Student to update cannot be null.", error);
         assertEquals(1, studentService.getAllStudents().size());
     }
 


### PR DESCRIPTION
# Summary

This is also a big PR but it's pretty repetitive for the most part. Here's what changed:

* Made new `BaseService` and `BaseServiceTest` classes, which the service and service test classes now extend from
* Added a prefix to error messages that looks like this `ERROR [Service]: <error>`
* Fixed some other small things wherever I found them

## Test Plan

`mvn test` and `mvn failsafe:integration-test`

## Related Issues

closes #114 
