### PR TITLE
Add service tests for ReportConfig and ReportSectionConfig

### DIFF
--- a/Backend/src/main/java/ca/mcgill/cooperator/controller/ControllerUtils.java
+++ b/Backend/src/main/java/ca/mcgill/cooperator/controller/ControllerUtils.java
@@ -1222,9 +1222,9 @@ public class ControllerUtils {
     public static List<ReportSectionConfig> convertReportSectionConfigDtosToDomainObjects(
             ReportSectionConfigService service, Collection<ReportSectionConfigDto> rscDtos) {
         List<ReportSectionConfig> reportSectionConfigs = new ArrayList<>();
-    	if (rscDtos == null) {
-    		return reportSectionConfigs;
-    	}
+        if (rscDtos == null) {
+            return reportSectionConfigs;
+        }
         for (ReportSectionConfigDto rscDto : rscDtos) {
             if (rscDto != null) {
                 ReportSectionConfig rsc = service.getReportSectionConfig(rscDto.getId());

--- a/Backend/src/main/java/ca/mcgill/cooperator/controller/ReportConfigController.java
+++ b/Backend/src/main/java/ca/mcgill/cooperator/controller/ReportConfigController.java
@@ -8,7 +8,6 @@ import ca.mcgill.cooperator.service.ReportSectionConfigService;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -72,15 +71,15 @@ public class ReportConfigController extends BaseController {
     @PutMapping("")
     public ReportConfigDto updateReportConfig(@RequestBody ReportConfigDto rcDto) {
         ReportConfig rc = reportConfigService.getReportConfig(rcDto.getId());
-        
+
         Set<ReportSectionConfig> rscConfigs = null;
         if (rcDto.getReportSectionConfigs() != null) {
-        	rscConfigs = new HashSet<>(
-                    ControllerUtils.convertReportSectionConfigDtosToDomainObjects(
-                            reportSectionConfigService,
-                            rcDto.getReportSectionConfigs()));
+            rscConfigs =
+                    new HashSet<>(
+                            ControllerUtils.convertReportSectionConfigDtosToDomainObjects(
+                                    reportSectionConfigService, rcDto.getReportSectionConfigs()));
         }
-        
+
         ReportConfig updatedReportConfig =
                 reportConfigService.updateReportConfig(
                         rc,

--- a/Backend/src/main/java/ca/mcgill/cooperator/service/ReportConfigService.java
+++ b/Backend/src/main/java/ca/mcgill/cooperator/service/ReportConfigService.java
@@ -131,7 +131,7 @@ public class ReportConfigService extends BaseService {
         if (reportConfig == null) {
             error.append("Report config to update cannot be null! ");
         }
-        if (deadline < 0) {
+        if (deadline != null && deadline < 0) {
             error.append("Deadline cannot be negative! ");
         }
         if (type != null && type.trim().length() == 0) {

--- a/Backend/src/main/java/ca/mcgill/cooperator/service/ReportSectionConfigService.java
+++ b/Backend/src/main/java/ca/mcgill/cooperator/service/ReportSectionConfigService.java
@@ -8,6 +8,7 @@ import ca.mcgill.cooperator.model.ReportResponseType;
 import ca.mcgill.cooperator.model.ReportSectionConfig;
 import ca.mcgill.cooperator.model.StudentReportSection;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import javax.transaction.Transactional;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -58,7 +59,7 @@ public class ReportSectionConfigService extends BaseService {
      * Retrieves an existing ReportSectionConfig by ID
      *
      * @param id
-     * @return ReportSectionConfig with matching iD
+     * @return ReportSectionConfig with matching ID
      */
     @Transactional
     public ReportSectionConfig getReportSectionConfig(int id) {
@@ -69,6 +70,16 @@ public class ReportSectionConfigService extends BaseService {
         }
 
         return rsConfig;
+    }
+
+    /**
+     * Retrieves all ReportSectionConfigs
+     *
+     * @return all ReportSectionConfigs
+     */
+    @Transactional
+    public List<ReportSectionConfig> getAllReportSectionConfigs() {
+        return ServiceUtils.toList(reportSectionConfigRepository.findAll());
     }
 
     /**

--- a/Backend/src/test/java/ca/mcgill/cooperator/service/BaseServiceTest.java
+++ b/Backend/src/test/java/ca/mcgill/cooperator/service/BaseServiceTest.java
@@ -146,9 +146,14 @@ public class BaseServiceTest {
         return service.createReportSection("This is a response", rsConfig, er);
     }
 
+    ReportConfig createTestReportConfig(ReportConfigService service) {
+        return service.createReportConfig(true, 14, true, "First Evaluation");
+    }
+
     ReportSectionConfig createTestReportSectionConfig(
             ReportConfigService rcService, ReportSectionConfigService rscService) {
-        ReportConfig reportConfig = rcService.createReportConfig(true, 14, true, "Evaluation");
+        ReportConfig reportConfig =
+                rcService.createReportConfig(true, 14, true, "First Evaluation");
 
         return rscService.createReportSectionConfig(
                 "How was your co-op?", ReportResponseType.LONG_TEXT, reportConfig);

--- a/Backend/src/test/java/ca/mcgill/cooperator/service/CooperatorServiceReportConfigTests.java
+++ b/Backend/src/test/java/ca/mcgill/cooperator/service/CooperatorServiceReportConfigTests.java
@@ -1,5 +1,11 @@
 package ca.mcgill.cooperator.service;
 
+import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import ca.mcgill.cooperator.dao.ReportConfigRepository;
+import ca.mcgill.cooperator.model.ReportConfig;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -7,50 +13,168 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
-import ca.mcgill.cooperator.dao.ReportConfigRepository;
-
 @SpringBootTest
 @ActiveProfiles("test")
-public class CooperatorServiceReportConfigTests {
-	
-	@Autowired ReportConfigService reportConfigService;
-	
-	@Autowired ReportConfigRepository reportConfigRepository;
-	
+public class CooperatorServiceReportConfigTests extends BaseServiceTest {
+
+    @Autowired ReportConfigService reportConfigService;
+
+    @Autowired ReportConfigRepository reportConfigRepository;
+
     @BeforeEach
     @AfterEach
     public void clearDatabase() {
         reportConfigRepository.deleteAll();
     }
-    
+
     @Test
     public void testCreateReportConfig() {
-    	
-    }
-    
-    @Test
-    public void testCreateReportConfigInvalid() {
-    	
-    }
-    
-    @Test
-    public void testUpdateReportConfig() {
-    	
-    }
-    
-    @Test
-    public void testUpdateReportConfigInvalid() {
-    	
-    }
-    
-    @Test
-    public void testDeleteReportConfig() {
-    	
-    }
-    
-    @Test 
-    public void testDeleteReportConfigInvalid() {
-    	
+        boolean requiresFile = true;
+        int deadline = 14;
+        boolean isDeadlineFromStart = true;
+        String type = "First Evaluation";
+
+        // 1. create valid ReportConfig
+        try {
+            reportConfigService.createReportConfig(
+                    requiresFile, deadline, isDeadlineFromStart, type);
+        } catch (IllegalArgumentException e) {
+            fail();
+        }
+
+        // 2. verify correctness
+        assertEquals(1, reportConfigService.getAllReportConfigs().size());
+
+        ReportConfig rc = reportConfigService.getReportConfig("First Evaluation");
+        assertEquals(14, rc.getDeadline());
+        assertTrue(rc.getRequiresFile());
+        assertTrue(rc.getIsDeadlineFromStart());
     }
 
+    @Test
+    public void testCreateReportConfigInvalid() {
+        try {
+            reportConfigService.createReportConfig(true, -1, false, "  ");
+        } catch (IllegalArgumentException e) {
+            assertEquals(
+                    ERROR_PREFIX + "Deadline cannot be negative! " + "Report type cannot be empty!",
+                    e.getMessage());
+            assertEquals(0, reportConfigService.getAllReportConfigs().size());
+        }
+    }
+
+    @Test
+    public void testUpdateReportConfig() {
+        boolean requiresFile = true;
+        int deadline = 14;
+        boolean isDeadlineFromStart = true;
+        String type = "First Evaluation";
+
+        // 1. create the ReportConfig
+        ReportConfig rc = null;
+        try {
+            rc =
+                    reportConfigService.createReportConfig(
+                            requiresFile, deadline, isDeadlineFromStart, type);
+        } catch (IllegalArgumentException e) {
+            fail();
+        }
+
+        // 2. update the type
+        try {
+            reportConfigService.updateReportConfig(rc, null, null, null, "Second Evaluation", null);
+        } catch (IllegalArgumentException e) {
+            fail();
+        }
+
+        // 3. try fetching by type
+        rc = reportConfigService.getReportConfig("Second Evaluation");
+        assertEquals(14, rc.getDeadline());
+        assertTrue(rc.getRequiresFile());
+        assertTrue(rc.getIsDeadlineFromStart());
+
+        // 4. update all fields
+        requiresFile = false;
+        deadline = 7;
+        isDeadlineFromStart = false;
+        type = "Third Evaluation";
+        try {
+            reportConfigService.updateReportConfig(
+                    rc, requiresFile, deadline, isDeadlineFromStart, type, null);
+        } catch (IllegalArgumentException e) {
+            fail();
+        }
+
+        // 5. verify changes
+        rc = reportConfigService.getReportConfig(type);
+        assertEquals(deadline, rc.getDeadline());
+        assertTrue(!rc.getRequiresFile());
+        assertTrue(!rc.getIsDeadlineFromStart());
+    }
+
+    @Test
+    public void testUpdateReportConfigInvalid() {
+        boolean requiresFile = true;
+        int deadline = 14;
+        boolean isDeadlineFromStart = true;
+        String type = "First Evaluation";
+
+        // 1. create the ReportConfig
+        try {
+            reportConfigService.createReportConfig(
+                    requiresFile, deadline, isDeadlineFromStart, type);
+        } catch (IllegalArgumentException e) {
+            fail();
+        }
+
+        // 2. invalid updates
+        try {
+            reportConfigService.updateReportConfig(null, null, -1, null, "", null);
+        } catch (IllegalArgumentException e) {
+            // 3. verify original ReportConfig is unchanged
+            assertEquals(
+                    ERROR_PREFIX
+                            + "Report config to update cannot be null! "
+                            + "Deadline cannot be negative! "
+                            + "Report type cannot be empty!",
+                    e.getMessage());
+            assertEquals(1, reportConfigService.getAllReportConfigs().size());
+        }
+
+        ReportConfig rc = reportConfigService.getReportConfig("First Evaluation");
+        assertEquals(14, rc.getDeadline());
+        assertTrue(rc.getRequiresFile());
+        assertTrue(rc.getIsDeadlineFromStart());
+    }
+
+    @Test
+    public void testDeleteReportConfig() {
+        boolean requiresFile = true;
+        int deadline = 14;
+        boolean isDeadlineFromStart = true;
+        String type = "First Evaluation";
+
+        // 1. create then delete the ReportConfig
+        try {
+            ReportConfig rc =
+                    reportConfigService.createReportConfig(
+                            requiresFile, deadline, isDeadlineFromStart, type);
+
+            reportConfigService.deleteReportConfig(rc);
+        } catch (IllegalArgumentException e) {
+            fail();
+        }
+
+        assertEquals(0, reportConfigService.getAllReportConfigs().size());
+    }
+
+    @Test
+    public void testDeleteReportConfigInvalid() {
+        try {
+            reportConfigService.deleteReportConfig(null);
+        } catch (IllegalArgumentException e) {
+            assertEquals(ERROR_PREFIX + "Report config to delete cannot be null!", e.getMessage());
+            assertEquals(0, reportConfigService.getAllReportConfigs().size());
+        }
+    }
 }

--- a/Backend/src/test/java/ca/mcgill/cooperator/service/CooperatorServiceReportConfigTests.java
+++ b/Backend/src/test/java/ca/mcgill/cooperator/service/CooperatorServiceReportConfigTests.java
@@ -1,0 +1,56 @@
+package ca.mcgill.cooperator.service;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import ca.mcgill.cooperator.dao.ReportConfigRepository;
+
+@SpringBootTest
+@ActiveProfiles("test")
+public class CooperatorServiceReportConfigTests {
+	
+	@Autowired ReportConfigService reportConfigService;
+	
+	@Autowired ReportConfigRepository reportConfigRepository;
+	
+    @BeforeEach
+    @AfterEach
+    public void clearDatabase() {
+        reportConfigRepository.deleteAll();
+    }
+    
+    @Test
+    public void testCreateReportConfig() {
+    	
+    }
+    
+    @Test
+    public void testCreateReportConfigInvalid() {
+    	
+    }
+    
+    @Test
+    public void testUpdateReportConfig() {
+    	
+    }
+    
+    @Test
+    public void testUpdateReportConfigInvalid() {
+    	
+    }
+    
+    @Test
+    public void testDeleteReportConfig() {
+    	
+    }
+    
+    @Test 
+    public void testDeleteReportConfigInvalid() {
+    	
+    }
+
+}

--- a/Backend/src/test/java/ca/mcgill/cooperator/service/CooperatorServiceReportConfigTests.java
+++ b/Backend/src/test/java/ca/mcgill/cooperator/service/CooperatorServiceReportConfigTests.java
@@ -2,6 +2,7 @@ package ca.mcgill.cooperator.service;
 
 import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import ca.mcgill.cooperator.dao.ReportConfigRepository;
@@ -108,8 +109,8 @@ public class CooperatorServiceReportConfigTests extends BaseServiceTest {
         // 5. verify changes
         rc = reportConfigService.getReportConfig(type);
         assertEquals(deadline, rc.getDeadline());
-        assertTrue(!rc.getRequiresFile());
-        assertTrue(!rc.getIsDeadlineFromStart());
+        assertFalse(rc.getRequiresFile());
+        assertFalse(rc.getIsDeadlineFromStart());
     }
 
     @Test

--- a/Backend/src/test/java/ca/mcgill/cooperator/service/CooperatorServiceReportSectionConfigTests.java
+++ b/Backend/src/test/java/ca/mcgill/cooperator/service/CooperatorServiceReportSectionConfigTests.java
@@ -1,0 +1,190 @@
+package ca.mcgill.cooperator.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import ca.mcgill.cooperator.dao.ReportConfigRepository;
+import ca.mcgill.cooperator.dao.ReportSectionConfigRepository;
+import ca.mcgill.cooperator.model.ReportConfig;
+import ca.mcgill.cooperator.model.ReportResponseType;
+import ca.mcgill.cooperator.model.ReportSectionConfig;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles("test")
+public class CooperatorServiceReportSectionConfigTests extends BaseServiceTest {
+
+    @Autowired ReportConfigService reportConfigService;
+    @Autowired ReportSectionConfigService reportSectionConfigService;
+
+    @Autowired ReportConfigRepository reportConfigRepository;
+    @Autowired ReportSectionConfigRepository reportSectionConfigRepository;
+
+    @BeforeEach
+    @AfterEach
+    public void clearDatabase() {
+        reportConfigRepository.deleteAll();
+        reportSectionConfigRepository.deleteAll();
+    }
+
+    @Test
+    public void testCreateReportSectionConfig() {
+        String prompt = "How was your co-op?";
+
+        // 1. create valid ReportSectionConfig
+        try {
+            ReportConfig rc = createTestReportConfig(reportConfigService);
+            reportSectionConfigService.createReportSectionConfig(
+                    prompt, ReportResponseType.LONG_TEXT, rc);
+        } catch (IllegalArgumentException e) {
+            fail();
+        }
+
+        // 2. verify correctness
+        List<ReportSectionConfig> rsConfigs =
+                reportSectionConfigService.getAllReportSectionConfigs();
+        assertEquals(1, rsConfigs.size());
+        assertEquals(prompt, rsConfigs.get(0).getSectionPrompt());
+        assertEquals(ReportResponseType.LONG_TEXT, rsConfigs.get(0).getResponseType());
+    }
+
+    @Test
+    public void testCreateReportSectionConfigInvalid() {
+        try {
+            reportSectionConfigService.createReportSectionConfig("  ", null, null);
+        } catch (IllegalArgumentException e) {
+            assertEquals(
+                    ERROR_PREFIX
+                            + "Section prompt cannot be empty! "
+                            + "Response type cannot be null! "
+                            + "Report config cannot be null!",
+                    e.getMessage());
+        }
+    }
+
+    @Test
+    public void testUpdateReportSectionConfig() {
+        String prompt = "How was your co-op?";
+
+        // 1. create ReportSectionConfig
+        ReportSectionConfig rsConfig = null;
+        ReportConfig rc = null;
+        try {
+            rc = createTestReportConfig(reportConfigService);
+            rsConfig =
+                    reportSectionConfigService.createReportSectionConfig(
+                            prompt, ReportResponseType.LONG_TEXT, rc);
+        } catch (IllegalArgumentException e) {
+            fail();
+        }
+
+        // 2. update prompt only
+        prompt = "Which tools did you use during your co-op?";
+        try {
+            reportSectionConfigService.updateReportSectionConfig(
+                    rsConfig, prompt, null, null, null, null);
+        } catch (IllegalArgumentException e) {
+            fail();
+        }
+
+        // 3. verify that only the prompt was changed
+        rsConfig = reportSectionConfigService.getReportSectionConfig(rsConfig.getId());
+        assertEquals(prompt, rsConfig.getSectionPrompt());
+        assertEquals(ReportResponseType.LONG_TEXT, rsConfig.getResponseType());
+        assertEquals(rc.getType(), rsConfig.getReportConfig().getType());
+
+        // 4. update all fields
+        prompt = "How was your co-op?";
+        try {
+            // update ReportConfig here without explicitly updating it below
+            rc =
+                    reportConfigService.updateReportConfig(
+                            rc, null, null, null, "Second Evaluation", null);
+
+            reportSectionConfigService.updateReportSectionConfig(
+                    rsConfig, prompt, ReportResponseType.SHORT_TEXT, null, null, null);
+        } catch (IllegalArgumentException e) {
+            fail();
+        }
+
+        // 5. verify correctness
+        rsConfig = reportSectionConfigService.getReportSectionConfig(rsConfig.getId());
+        assertEquals(prompt, rsConfig.getSectionPrompt());
+        assertEquals(ReportResponseType.SHORT_TEXT, rsConfig.getResponseType());
+        assertEquals(rc.getType(), rsConfig.getReportConfig().getType());
+    }
+
+    @Test
+    public void testUpdateReportSectionConfigInvalid() {
+        String prompt = "How was your co-op?";
+
+        // 1. create ReportSectionConfig
+        try {
+            ReportConfig rc = createTestReportConfig(reportConfigService);
+            reportSectionConfigService.createReportSectionConfig(
+                    prompt, ReportResponseType.LONG_TEXT, rc);
+        } catch (IllegalArgumentException e) {
+            fail();
+        }
+
+        // 2. invalid updates
+        try {
+            reportSectionConfigService.updateReportSectionConfig(null, " ", null, null, null, null);
+        } catch (IllegalArgumentException e) {
+            assertEquals(
+                    ERROR_PREFIX
+                            + "Report section config to update cannot be null! "
+                            + "Section prompt cannot be empty!",
+                    e.getMessage());
+        }
+
+        // 3. verify original ReportSectionConfig is unchanged
+        List<ReportSectionConfig> rsConfigs =
+                reportSectionConfigService.getAllReportSectionConfigs();
+        assertEquals(1, rsConfigs.size());
+        assertEquals(prompt, rsConfigs.get(0).getSectionPrompt());
+        assertEquals(ReportResponseType.LONG_TEXT, rsConfigs.get(0).getResponseType());
+    }
+
+    @Test
+    public void testDeleteReportSectionConfig() {
+        String prompt = "How was your co-op?";
+
+        // 1. create and delete ReportSectionConfig
+        try {
+            ReportConfig rc = createTestReportConfig(reportConfigService);
+            ReportSectionConfig rsc =
+                    reportSectionConfigService.createReportSectionConfig(
+                            prompt, ReportResponseType.LONG_TEXT, rc);
+
+            reportSectionConfigService.deleteReportSectionConfig(rsc);
+        } catch (IllegalArgumentException e) {
+            fail();
+        }
+
+        List<ReportSectionConfig> rsConfigs =
+                reportSectionConfigService.getAllReportSectionConfigs();
+        assertEquals(0, rsConfigs.size());
+    }
+
+    @Test
+    public void testDeleteReportSectionConfigInvalid() {
+        try {
+            reportSectionConfigService.deleteReportSectionConfig(null);
+        } catch (IllegalArgumentException e) {
+            assertEquals(
+                    ERROR_PREFIX + "Report section config to delete cannot be null!",
+                    e.getMessage());
+        }
+
+        List<ReportSectionConfig> rsConfigs =
+                reportSectionConfigService.getAllReportSectionConfigs();
+        assertEquals(0, rsConfigs.size());
+    }
+}


### PR DESCRIPTION
# Summary

`ReportConfig` and `ReportSectionConfig` are new classes that are currently untested, so this PR adds the service-layer tests for them. The next PR will add controller integration tests.

## Test Plan

`mvn test`

## Related Issues

#111 
