### PR TITLE
Add unique constraints to model classes

### DIFF
--- a/Backend/src/main/java/ca/mcgill/cooperator/model/Admin.java
+++ b/Backend/src/main/java/ca/mcgill/cooperator/model/Admin.java
@@ -2,6 +2,7 @@ package ca.mcgill.cooperator.model;
 
 import java.util.List;
 import javax.persistence.CascadeType;
+import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
@@ -15,6 +16,8 @@ public class Admin {
     @Id @GeneratedValue private int id;
     private String firstName;
     private String lastName;
+
+    @Column(unique = true)
     private String email;
 
     @OneToMany(

--- a/Backend/src/main/java/ca/mcgill/cooperator/model/Course.java
+++ b/Backend/src/main/java/ca/mcgill/cooperator/model/Course.java
@@ -2,6 +2,7 @@ package ca.mcgill.cooperator.model;
 
 import java.util.List;
 import javax.persistence.CascadeType;
+import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
@@ -13,6 +14,8 @@ import org.hibernate.annotations.OnDeleteAction;
 @Entity
 public class Course {
     @Id @GeneratedValue private int id;
+
+    @Column(unique = true)
     private String name;
 
     @OneToMany(

--- a/Backend/src/main/java/ca/mcgill/cooperator/model/EmployerContact.java
+++ b/Backend/src/main/java/ca/mcgill/cooperator/model/EmployerContact.java
@@ -2,6 +2,7 @@ package ca.mcgill.cooperator.model;
 
 import java.util.Set;
 import javax.persistence.CascadeType;
+import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
@@ -12,7 +13,10 @@ import javax.persistence.OneToMany;
 @Entity
 public class EmployerContact {
     @Id @GeneratedValue private int id;
+
+    @Column(unique = true)
     private String email;
+
     private String firstName;
     private String lastName;
     private String phoneNumber;

--- a/Backend/src/main/java/ca/mcgill/cooperator/model/ReportConfig.java
+++ b/Backend/src/main/java/ca/mcgill/cooperator/model/ReportConfig.java
@@ -2,6 +2,7 @@ package ca.mcgill.cooperator.model;
 
 import java.util.Set;
 import javax.persistence.CascadeType;
+import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
@@ -16,6 +17,8 @@ public class ReportConfig {
     private boolean requiresFile;
     private int deadline;
     private boolean isDeadlineFromStart;
+
+    @Column(unique = true)
     private String type;
 
     @OneToMany(

--- a/Backend/src/main/java/ca/mcgill/cooperator/model/Student.java
+++ b/Backend/src/main/java/ca/mcgill/cooperator/model/Student.java
@@ -2,6 +2,7 @@ package ca.mcgill.cooperator.model;
 
 import java.util.Set;
 import javax.persistence.CascadeType;
+import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
@@ -15,7 +16,11 @@ public class Student {
     @Id @GeneratedValue private int id;
     private String firstName;
     private String lastName;
+
+    @Column(unique = true)
     private String email;
+
+    @Column(unique = true)
     private String studentId;
 
     @OneToMany(

--- a/Backend/src/test/java/ca/mcgill/cooperator/cucumber/StudentUploadReportIT.java
+++ b/Backend/src/test/java/ca/mcgill/cooperator/cucumber/StudentUploadReportIT.java
@@ -9,6 +9,7 @@ import ca.mcgill.cooperator.dao.CompanyRepository;
 import ca.mcgill.cooperator.dao.CoopDetailsRepository;
 import ca.mcgill.cooperator.dao.CourseOfferingRepository;
 import ca.mcgill.cooperator.dao.CourseRepository;
+import ca.mcgill.cooperator.dao.ReportConfigRepository;
 import ca.mcgill.cooperator.dao.StudentRepository;
 import ca.mcgill.cooperator.dto.CompanyDto;
 import ca.mcgill.cooperator.dto.CoopDetailsDto;
@@ -64,6 +65,7 @@ public class StudentUploadReportIT extends BaseControllerIT {
     @Autowired private CourseRepository courseRepository;
     @Autowired private CourseOfferingRepository courseOfferingRepository;
     @Autowired private CoopDetailsRepository coopDetailsRepository;
+    @Autowired private ReportConfigRepository reportConfigRepository;
 
     @Autowired private CoopDetailsService coopDetailsService;
     @Autowired private StudentReportSectionService studentReportSectionService;
@@ -112,6 +114,7 @@ public class StudentUploadReportIT extends BaseControllerIT {
         courseRepository.deleteAll();
         courseOfferingRepository.deleteAll();
         coopDetailsRepository.deleteAll();
+        reportConfigRepository.deleteAll();
     }
 
     @Given("the Student is currently doing a Coop term")

--- a/Backend/src/test/java/ca/mcgill/cooperator/service/BaseServiceTest.java
+++ b/Backend/src/test/java/ca/mcgill/cooperator/service/BaseServiceTest.java
@@ -151,7 +151,9 @@ public class BaseServiceTest {
     }
 
     ReportSectionConfig createTestReportSectionConfig(
-            ReportConfigService rcService, ReportSectionConfigService rscService, ReportConfig reportConfig) {
+            ReportConfigService rcService,
+            ReportSectionConfigService rscService,
+            ReportConfig reportConfig) {
         return rscService.createReportSectionConfig(
                 "How was your co-op?", ReportResponseType.LONG_TEXT, reportConfig);
     }

--- a/Backend/src/test/java/ca/mcgill/cooperator/service/BaseServiceTest.java
+++ b/Backend/src/test/java/ca/mcgill/cooperator/service/BaseServiceTest.java
@@ -146,15 +146,12 @@ public class BaseServiceTest {
         return service.createReportSection("This is a response", rsConfig, er);
     }
 
-    ReportConfig createTestReportConfig(ReportConfigService service) {
-        return service.createReportConfig(true, 14, true, "First Evaluation");
+    ReportConfig createTestReportConfig(ReportConfigService service, String type) {
+        return service.createReportConfig(true, 14, true, type);
     }
 
     ReportSectionConfig createTestReportSectionConfig(
-            ReportConfigService rcService, ReportSectionConfigService rscService) {
-        ReportConfig reportConfig =
-                rcService.createReportConfig(true, 14, true, "First Evaluation");
-
+            ReportConfigService rcService, ReportSectionConfigService rscService, ReportConfig reportConfig) {
         return rscService.createReportSectionConfig(
                 "How was your co-op?", ReportResponseType.LONG_TEXT, reportConfig);
     }

--- a/Backend/src/test/java/ca/mcgill/cooperator/service/CooperatorServiceAdminTests.java
+++ b/Backend/src/test/java/ca/mcgill/cooperator/service/CooperatorServiceAdminTests.java
@@ -51,6 +51,20 @@ public class CooperatorServiceAdminTests extends BaseServiceTest {
     }
 
     @Test
+    public void testAdminUniqueEmail() {
+        String firstName = "Paul";
+        String lastName = "Hooley";
+        String email = "phooley@gmail.com";
+        try {
+            adminService.createAdmin(firstName, lastName, email);
+            // email must be unique so expect a SQLException
+            adminService.createAdmin(firstName, lastName, email);
+        } catch (Exception e) {
+            assertEquals(1, adminService.getAllAdmins().size());
+        }
+    }
+
+    @Test
     public void testCreateAdminInvalidEmail() {
         String firstName = "Paul";
         String lastName = "Hooley";

--- a/Backend/src/test/java/ca/mcgill/cooperator/service/CooperatorServiceCourseOfferingTests.java
+++ b/Backend/src/test/java/ca/mcgill/cooperator/service/CooperatorServiceCourseOfferingTests.java
@@ -92,7 +92,8 @@ public class CooperatorServiceCourseOfferingTests extends BaseServiceTest {
 
         int year2 = 2021;
         Season season2 = Season.FALL;
-        Course c2 = courseService.createCourse(name);
+        String name2 = "ECSE223";
+        Course c2 = courseService.createCourse(name2);
 
         try {
             courseOfferingService.updateCourseOffering(co, year2, season2, c2);

--- a/Backend/src/test/java/ca/mcgill/cooperator/service/CooperatorServiceCourseTests.java
+++ b/Backend/src/test/java/ca/mcgill/cooperator/service/CooperatorServiceCourseTests.java
@@ -42,6 +42,18 @@ public class CooperatorServiceCourseTests extends BaseServiceTest {
     }
 
     @Test
+    public void testCourseUniqueName() {
+        String name = "ECSE321";
+        try {
+            courseService.createCourse(name);
+            // name must be unique so expect a SQLException
+            courseService.createCourse(name);
+        } catch (Exception e) {
+            assertEquals(1, courseService.getAllCourses().size());
+        }
+    }
+
+    @Test
     public void testCreateCourseNull() {
         String name = null;
         String error = "";

--- a/Backend/src/test/java/ca/mcgill/cooperator/service/CooperatorServiceEmployerContactTests.java
+++ b/Backend/src/test/java/ca/mcgill/cooperator/service/CooperatorServiceEmployerContactTests.java
@@ -86,6 +86,25 @@ public class CooperatorServiceEmployerContactTests extends BaseServiceTest {
     }
 
     @Test
+    public void testEmployerContactUniqueEmail() {
+        String firstName = "Paul";
+        String lastName = "Hooley";
+        String email = "phooley@gmail.com";
+        String phoneNumber = "0123456789";
+        Company c = createTestCompany(companyService);
+
+        try {
+            employerContactService.createEmployerContact(
+                    firstName, lastName, email, phoneNumber, c);
+            // email must be unique so expect a SQLException
+            employerContactService.createEmployerContact(
+                    firstName, lastName, email, phoneNumber, c);
+        } catch (Exception e) {
+            assertEquals(1, employerContactService.getAllEmployerContacts().size());
+        }
+    }
+
+    @Test
     public void testCreateEmployerContactInvalidEmail() {
         String firstName = "Paul";
         String lastName = "Hooley";

--- a/Backend/src/test/java/ca/mcgill/cooperator/service/CooperatorServiceEmployerReportSectionTests.java
+++ b/Backend/src/test/java/ca/mcgill/cooperator/service/CooperatorServiceEmployerReportSectionTests.java
@@ -233,7 +233,7 @@ public class CooperatorServiceEmployerReportSectionTests extends BaseServiceTest
         Student s = createTestStudent(studentService);
         Coop coop = createTestCoop(coopService, courseOffering, s);
         Company c = createTestCompany(companyService);
-        EmployerContact ec = createTestEmployerContact(employerContactService, c);        
+        EmployerContact ec = createTestEmployerContact(employerContactService, c);
         ReportConfig rc = createTestReportConfig(reportConfigService, "First Evaluation");
         ReportSectionConfig rsConfig =
                 createTestReportSectionConfig(reportConfigService, reportSectionConfigService, rc);

--- a/Backend/src/test/java/ca/mcgill/cooperator/service/CooperatorServiceEmployerReportSectionTests.java
+++ b/Backend/src/test/java/ca/mcgill/cooperator/service/CooperatorServiceEmployerReportSectionTests.java
@@ -10,6 +10,7 @@ import ca.mcgill.cooperator.dao.CourseRepository;
 import ca.mcgill.cooperator.dao.EmployerContactRepository;
 import ca.mcgill.cooperator.dao.EmployerReportRepository;
 import ca.mcgill.cooperator.dao.EmployerReportSectionRepository;
+import ca.mcgill.cooperator.dao.ReportConfigRepository;
 import ca.mcgill.cooperator.dao.StudentRepository;
 import ca.mcgill.cooperator.model.Company;
 import ca.mcgill.cooperator.model.Coop;
@@ -18,6 +19,7 @@ import ca.mcgill.cooperator.model.CourseOffering;
 import ca.mcgill.cooperator.model.EmployerContact;
 import ca.mcgill.cooperator.model.EmployerReport;
 import ca.mcgill.cooperator.model.EmployerReportSection;
+import ca.mcgill.cooperator.model.ReportConfig;
 import ca.mcgill.cooperator.model.ReportSectionConfig;
 import ca.mcgill.cooperator.model.Student;
 import java.util.List;
@@ -40,6 +42,7 @@ public class CooperatorServiceEmployerReportSectionTests extends BaseServiceTest
     @Autowired CourseRepository courseRepository;
     @Autowired CourseOfferingRepository courseOfferingRepository;
     @Autowired StudentRepository studentRepository;
+    @Autowired ReportConfigRepository reportConfigRepository;
 
     @Autowired EmployerContactService employerContactService;
     @Autowired EmployerReportSectionService employerReportSectionService;
@@ -69,6 +72,7 @@ public class CooperatorServiceEmployerReportSectionTests extends BaseServiceTest
         employerReportSectionRepository.deleteAll();
         employerReportRepository.deleteAll();
         companyRepository.deleteAll();
+        reportConfigRepository.deleteAll();
     }
 
     @Test
@@ -80,8 +84,9 @@ public class CooperatorServiceEmployerReportSectionTests extends BaseServiceTest
         Coop coop = createTestCoop(coopService, courseOffering, s);
         Company c = createTestCompany(companyService);
         EmployerContact ec = createTestEmployerContact(employerContactService, c);
+        ReportConfig rc = createTestReportConfig(reportConfigService, "First Evaluation");
         ReportSectionConfig rsConfig =
-                createTestReportSectionConfig(reportConfigService, reportSectionConfigService);
+                createTestReportSectionConfig(reportConfigService, reportSectionConfigService, rc);
         EmployerReport er = createTestEmployerReport(employerReportService, coop, ec);
 
         try {
@@ -157,8 +162,9 @@ public class CooperatorServiceEmployerReportSectionTests extends BaseServiceTest
         Coop coop = createTestCoop(coopService, courseOffering, s);
         Company c = createTestCompany(companyService);
         EmployerContact ec = createTestEmployerContact(employerContactService, c);
+        ReportConfig rc = createTestReportConfig(reportConfigService, "First Evaluation");
         ReportSectionConfig rsConfig =
-                createTestReportSectionConfig(reportConfigService, reportSectionConfigService);
+                createTestReportSectionConfig(reportConfigService, reportSectionConfigService, rc);
         EmployerReport er = createTestEmployerReport(employerReportService, coop, ec);
 
         try {
@@ -194,8 +200,9 @@ public class CooperatorServiceEmployerReportSectionTests extends BaseServiceTest
         Coop coop = createTestCoop(coopService, courseOffering, s);
         Company c = createTestCompany(companyService);
         EmployerContact ec = createTestEmployerContact(employerContactService, c);
+        ReportConfig rc = createTestReportConfig(reportConfigService, "First Evaluation");
         ReportSectionConfig rsConfig =
-                createTestReportSectionConfig(reportConfigService, reportSectionConfigService);
+                createTestReportSectionConfig(reportConfigService, reportSectionConfigService, rc);
         EmployerReport er = createTestEmployerReport(employerReportService, coop, ec);
 
         try {
@@ -226,9 +233,10 @@ public class CooperatorServiceEmployerReportSectionTests extends BaseServiceTest
         Student s = createTestStudent(studentService);
         Coop coop = createTestCoop(coopService, courseOffering, s);
         Company c = createTestCompany(companyService);
-        EmployerContact ec = createTestEmployerContact(employerContactService, c);
+        EmployerContact ec = createTestEmployerContact(employerContactService, c);        
+        ReportConfig rc = createTestReportConfig(reportConfigService, "First Evaluation");
         ReportSectionConfig rsConfig =
-                createTestReportSectionConfig(reportConfigService, reportSectionConfigService);
+                createTestReportSectionConfig(reportConfigService, reportSectionConfigService, rc);
         EmployerReport er = createTestEmployerReport(employerReportService, coop, ec);
 
         try {
@@ -257,8 +265,9 @@ public class CooperatorServiceEmployerReportSectionTests extends BaseServiceTest
         Coop coop = createTestCoop(coopService, courseOffering, s);
         Company c = createTestCompany(companyService);
         EmployerContact ec = createTestEmployerContact(employerContactService, c);
+        ReportConfig rc = createTestReportConfig(reportConfigService, "First Evaluation");
         ReportSectionConfig rsConfig =
-                createTestReportSectionConfig(reportConfigService, reportSectionConfigService);
+                createTestReportSectionConfig(reportConfigService, reportSectionConfigService, rc);
         EmployerReport er = createTestEmployerReport(employerReportService, coop, ec);
 
         try {
@@ -285,8 +294,9 @@ public class CooperatorServiceEmployerReportSectionTests extends BaseServiceTest
         Coop coop = createTestCoop(coopService, courseOffering, s);
         Company c = createTestCompany(companyService);
         EmployerContact ec = createTestEmployerContact(employerContactService, c);
+        ReportConfig rc = createTestReportConfig(reportConfigService, "First Evaluation");
         ReportSectionConfig rsConfig =
-                createTestReportSectionConfig(reportConfigService, reportSectionConfigService);
+                createTestReportSectionConfig(reportConfigService, reportSectionConfigService, rc);
         EmployerReport er = createTestEmployerReport(employerReportService, coop, ec);
 
         try {

--- a/Backend/src/test/java/ca/mcgill/cooperator/service/CooperatorServiceEmployerReportTests.java
+++ b/Backend/src/test/java/ca/mcgill/cooperator/service/CooperatorServiceEmployerReportTests.java
@@ -19,6 +19,7 @@ import ca.mcgill.cooperator.model.CourseOffering;
 import ca.mcgill.cooperator.model.EmployerContact;
 import ca.mcgill.cooperator.model.EmployerReport;
 import ca.mcgill.cooperator.model.EmployerReportSection;
+import ca.mcgill.cooperator.model.ReportConfig;
 import ca.mcgill.cooperator.model.ReportSectionConfig;
 import ca.mcgill.cooperator.model.ReportStatus;
 import ca.mcgill.cooperator.model.Student;
@@ -146,8 +147,9 @@ public class CooperatorServiceEmployerReportTests extends BaseServiceTest {
         Coop coop = createTestCoop(coopService, courseOffering, s);
         Company company = createTestCompany(companyService);
         EmployerContact ec = createTestEmployerContact(employerContactService, company);
+        ReportConfig rc = createTestReportConfig(reportConfigService, "First Evaluation");
         ReportSectionConfig rsConfig =
-                createTestReportSectionConfig(reportConfigService, reportSectionConfigService);
+                createTestReportSectionConfig(reportConfigService, reportSectionConfigService, rc);
 
         MultipartFile multipartFile = null;
         try {
@@ -192,8 +194,9 @@ public class CooperatorServiceEmployerReportTests extends BaseServiceTest {
         Coop coop = createTestCoop(coopService, courseOffering, s);
         Company company = createTestCompany(companyService);
         EmployerContact ec = createTestEmployerContact(employerContactService, company);
+        ReportConfig rc = createTestReportConfig(reportConfigService, "First Evaluation");
         ReportSectionConfig rsConfig =
-                createTestReportSectionConfig(reportConfigService, reportSectionConfigService);
+                createTestReportSectionConfig(reportConfigService, reportSectionConfigService, rc);
 
         MultipartFile multipartFile = null;
         try {

--- a/Backend/src/test/java/ca/mcgill/cooperator/service/CooperatorServiceReportConfigTests.java
+++ b/Backend/src/test/java/ca/mcgill/cooperator/service/CooperatorServiceReportConfigTests.java
@@ -53,6 +53,24 @@ public class CooperatorServiceReportConfigTests extends BaseServiceTest {
     }
 
     @Test
+    public void testReportConfigUniqueType() {
+        boolean requiresFile = true;
+        int deadline = 14;
+        boolean isDeadlineFromStart = true;
+        String type = "First Evaluation";
+
+        try {
+            reportConfigService.createReportConfig(
+                    requiresFile, deadline, isDeadlineFromStart, type);
+            // type must be unique so expect a SQLException
+            reportConfigService.createReportConfig(
+                    requiresFile, deadline, isDeadlineFromStart, type);
+        } catch (Exception e) {
+            assertEquals(1, reportConfigService.getAllReportConfigs().size());
+        }
+    }
+
+    @Test
     public void testCreateReportConfigInvalid() {
         try {
             reportConfigService.createReportConfig(true, -1, false, "  ");

--- a/Backend/src/test/java/ca/mcgill/cooperator/service/CooperatorServiceReportSectionConfigTests.java
+++ b/Backend/src/test/java/ca/mcgill/cooperator/service/CooperatorServiceReportSectionConfigTests.java
@@ -39,7 +39,7 @@ public class CooperatorServiceReportSectionConfigTests extends BaseServiceTest {
 
         // 1. create valid ReportSectionConfig
         try {
-            ReportConfig rc = createTestReportConfig(reportConfigService);
+            ReportConfig rc = createTestReportConfig(reportConfigService, "First Evaluation");
             reportSectionConfigService.createReportSectionConfig(
                     prompt, ReportResponseType.LONG_TEXT, rc);
         } catch (IllegalArgumentException e) {
@@ -76,7 +76,7 @@ public class CooperatorServiceReportSectionConfigTests extends BaseServiceTest {
         ReportSectionConfig rsConfig = null;
         ReportConfig rc = null;
         try {
-            rc = createTestReportConfig(reportConfigService);
+        	rc = createTestReportConfig(reportConfigService, "First Evaluation");
             rsConfig =
                     reportSectionConfigService.createReportSectionConfig(
                             prompt, ReportResponseType.LONG_TEXT, rc);
@@ -126,7 +126,7 @@ public class CooperatorServiceReportSectionConfigTests extends BaseServiceTest {
 
         // 1. create ReportSectionConfig
         try {
-            ReportConfig rc = createTestReportConfig(reportConfigService);
+        	ReportConfig rc = createTestReportConfig(reportConfigService, "First Evaluation");
             reportSectionConfigService.createReportSectionConfig(
                     prompt, ReportResponseType.LONG_TEXT, rc);
         } catch (IllegalArgumentException e) {
@@ -158,7 +158,7 @@ public class CooperatorServiceReportSectionConfigTests extends BaseServiceTest {
 
         // 1. create and delete ReportSectionConfig
         try {
-            ReportConfig rc = createTestReportConfig(reportConfigService);
+        	ReportConfig rc = createTestReportConfig(reportConfigService, "First Evaluation");
             ReportSectionConfig rsc =
                     reportSectionConfigService.createReportSectionConfig(
                             prompt, ReportResponseType.LONG_TEXT, rc);

--- a/Backend/src/test/java/ca/mcgill/cooperator/service/CooperatorServiceReportSectionConfigTests.java
+++ b/Backend/src/test/java/ca/mcgill/cooperator/service/CooperatorServiceReportSectionConfigTests.java
@@ -76,7 +76,7 @@ public class CooperatorServiceReportSectionConfigTests extends BaseServiceTest {
         ReportSectionConfig rsConfig = null;
         ReportConfig rc = null;
         try {
-        	rc = createTestReportConfig(reportConfigService, "First Evaluation");
+            rc = createTestReportConfig(reportConfigService, "First Evaluation");
             rsConfig =
                     reportSectionConfigService.createReportSectionConfig(
                             prompt, ReportResponseType.LONG_TEXT, rc);
@@ -126,7 +126,7 @@ public class CooperatorServiceReportSectionConfigTests extends BaseServiceTest {
 
         // 1. create ReportSectionConfig
         try {
-        	ReportConfig rc = createTestReportConfig(reportConfigService, "First Evaluation");
+            ReportConfig rc = createTestReportConfig(reportConfigService, "First Evaluation");
             reportSectionConfigService.createReportSectionConfig(
                     prompt, ReportResponseType.LONG_TEXT, rc);
         } catch (IllegalArgumentException e) {
@@ -158,7 +158,7 @@ public class CooperatorServiceReportSectionConfigTests extends BaseServiceTest {
 
         // 1. create and delete ReportSectionConfig
         try {
-        	ReportConfig rc = createTestReportConfig(reportConfigService, "First Evaluation");
+            ReportConfig rc = createTestReportConfig(reportConfigService, "First Evaluation");
             ReportSectionConfig rsc =
                     reportSectionConfigService.createReportSectionConfig(
                             prompt, ReportResponseType.LONG_TEXT, rc);

--- a/Backend/src/test/java/ca/mcgill/cooperator/service/CooperatorServiceStudentReportSectionTests.java
+++ b/Backend/src/test/java/ca/mcgill/cooperator/service/CooperatorServiceStudentReportSectionTests.java
@@ -7,12 +7,14 @@ import ca.mcgill.cooperator.dao.CoopRepository;
 import ca.mcgill.cooperator.dao.CourseOfferingRepository;
 import ca.mcgill.cooperator.dao.CourseRepository;
 import ca.mcgill.cooperator.dao.EmployerContactRepository;
+import ca.mcgill.cooperator.dao.ReportConfigRepository;
 import ca.mcgill.cooperator.dao.StudentReportRepository;
 import ca.mcgill.cooperator.dao.StudentReportSectionRepository;
 import ca.mcgill.cooperator.dao.StudentRepository;
 import ca.mcgill.cooperator.model.Coop;
 import ca.mcgill.cooperator.model.Course;
 import ca.mcgill.cooperator.model.CourseOffering;
+import ca.mcgill.cooperator.model.ReportConfig;
 import ca.mcgill.cooperator.model.ReportSectionConfig;
 import ca.mcgill.cooperator.model.Student;
 import ca.mcgill.cooperator.model.StudentReport;
@@ -36,6 +38,7 @@ public class CooperatorServiceStudentReportSectionTests extends BaseServiceTest 
     @Autowired CourseOfferingRepository courseOfferingRepository;
     @Autowired EmployerContactRepository employerContactRepository;
     @Autowired StudentRepository studentRepository;
+    @Autowired ReportConfigRepository reportConfigRepository;
 
     @Autowired StudentReportSectionService studentReportSectionService;
     @Autowired StudentReportService studentReportService;
@@ -62,6 +65,7 @@ public class CooperatorServiceStudentReportSectionTests extends BaseServiceTest 
         studentRepository.deleteAll();
         studentReportSectionRepository.deleteAll();
         studentReportRepository.deleteAll();
+        reportConfigRepository.deleteAll();
     }
 
     @Test
@@ -72,8 +76,9 @@ public class CooperatorServiceStudentReportSectionTests extends BaseServiceTest 
         Student s = createTestStudent(studentService);
         Coop coop = createTestCoop(coopService, courseOffering, s);
         StudentReport sr = createTestStudentReport(studentReportService, coop);
+        ReportConfig rc = createTestReportConfig(reportConfigService, "First Evaluation");
         ReportSectionConfig rsConfig =
-                createTestReportSectionConfig(reportConfigService, reportSectionConfigService);
+                createTestReportSectionConfig(reportConfigService, reportSectionConfigService, rc);
 
         try {
             studentReportSectionService.createReportSection(response, rsConfig, sr);
@@ -147,8 +152,9 @@ public class CooperatorServiceStudentReportSectionTests extends BaseServiceTest 
         Student s = createTestStudent(studentService);
         Coop coop = createTestCoop(coopService, courseOffering, s);
         StudentReport sr = createTestStudentReport(studentReportService, coop);
+        ReportConfig rc = createTestReportConfig(reportConfigService, "First Evaluation");
         ReportSectionConfig rsConfig =
-                createTestReportSectionConfig(reportConfigService, reportSectionConfigService);
+                createTestReportSectionConfig(reportConfigService, reportSectionConfigService, rc);
 
         try {
             rs = studentReportSectionService.createReportSection(response, rsConfig, sr);
@@ -184,8 +190,9 @@ public class CooperatorServiceStudentReportSectionTests extends BaseServiceTest 
         Student s = createTestStudent(studentService);
         Coop coop = createTestCoop(coopService, courseOffering, s);
         StudentReport sr = createTestStudentReport(studentReportService, coop);
+        ReportConfig rc = createTestReportConfig(reportConfigService, "First Evaluation");
         ReportSectionConfig rsConfig =
-                createTestReportSectionConfig(reportConfigService, reportSectionConfigService);
+                createTestReportSectionConfig(reportConfigService, reportSectionConfigService, rc);
 
         try {
             studentReportSectionService.createReportSection(response, rsConfig, sr);
@@ -217,8 +224,9 @@ public class CooperatorServiceStudentReportSectionTests extends BaseServiceTest 
         Student s = createTestStudent(studentService);
         Coop coop = createTestCoop(coopService, courseOffering, s);
         StudentReport sr = createTestStudentReport(studentReportService, coop);
+        ReportConfig rc = createTestReportConfig(reportConfigService, "First Evaluation");
         ReportSectionConfig rsConfig =
-                createTestReportSectionConfig(reportConfigService, reportSectionConfigService);
+                createTestReportSectionConfig(reportConfigService, reportSectionConfigService, rc);
 
         try {
             studentReportSectionService.createReportSection(response, rsConfig, sr);
@@ -247,8 +255,9 @@ public class CooperatorServiceStudentReportSectionTests extends BaseServiceTest 
         Student s = createTestStudent(studentService);
         Coop coop = createTestCoop(coopService, courseOffering, s);
         StudentReport sr = createTestStudentReport(studentReportService, coop);
+        ReportConfig rc = createTestReportConfig(reportConfigService, "First Evaluation");
         ReportSectionConfig rsConfig =
-                createTestReportSectionConfig(reportConfigService, reportSectionConfigService);
+                createTestReportSectionConfig(reportConfigService, reportSectionConfigService, rc);
 
         try {
             rs = studentReportSectionService.createReportSection(response, rsConfig, sr);
@@ -276,8 +285,9 @@ public class CooperatorServiceStudentReportSectionTests extends BaseServiceTest 
         Student s = createTestStudent(studentService);
         Coop coop = createTestCoop(coopService, courseOffering, s);
         StudentReport sr = createTestStudentReport(studentReportService, coop);
+        ReportConfig rc = createTestReportConfig(reportConfigService, "First Evaluation");
         ReportSectionConfig rsConfig =
-                createTestReportSectionConfig(reportConfigService, reportSectionConfigService);
+                createTestReportSectionConfig(reportConfigService, reportSectionConfigService, rc);
 
         try {
             rs = studentReportSectionService.createReportSection(response, rsConfig, sr);

--- a/Backend/src/test/java/ca/mcgill/cooperator/service/CooperatorServiceStudentReportTests.java
+++ b/Backend/src/test/java/ca/mcgill/cooperator/service/CooperatorServiceStudentReportTests.java
@@ -13,6 +13,7 @@ import ca.mcgill.cooperator.dao.StudentRepository;
 import ca.mcgill.cooperator.model.Coop;
 import ca.mcgill.cooperator.model.Course;
 import ca.mcgill.cooperator.model.CourseOffering;
+import ca.mcgill.cooperator.model.ReportConfig;
 import ca.mcgill.cooperator.model.ReportSectionConfig;
 import ca.mcgill.cooperator.model.ReportStatus;
 import ca.mcgill.cooperator.model.Student;
@@ -121,8 +122,9 @@ public class CooperatorServiceStudentReportTests extends BaseServiceTest {
         CourseOffering courseOffering = createTestCourseOffering(courseOfferingService, course);
         Student s = createTestStudent(studentService);
         Coop coop = createTestCoop(coopService, courseOffering, s);
+        ReportConfig rc = createTestReportConfig(reportConfigService, "First Evaluation");
         ReportSectionConfig rsConfig =
-                createTestReportSectionConfig(reportConfigService, reportSectionConfigService);
+                createTestReportSectionConfig(reportConfigService, reportSectionConfigService, rc);
 
         // 1. create Student Report
         MultipartFile multipartFile = null;
@@ -172,8 +174,9 @@ public class CooperatorServiceStudentReportTests extends BaseServiceTest {
         CourseOffering courseOffering = createTestCourseOffering(courseOfferingService, course);
         Student s = createTestStudent(studentService);
         Coop coop = createTestCoop(coopService, courseOffering, s);
+        ReportConfig rc = createTestReportConfig(reportConfigService, "First Evaluation");
         ReportSectionConfig rsConfig =
-                createTestReportSectionConfig(reportConfigService, reportSectionConfigService);
+                createTestReportSectionConfig(reportConfigService, reportSectionConfigService, rc);
 
         // 1. create Student Report
         MultipartFile multipartFile = null;

--- a/Backend/src/test/java/ca/mcgill/cooperator/service/CooperatorServiceStudentTests.java
+++ b/Backend/src/test/java/ca/mcgill/cooperator/service/CooperatorServiceStudentTests.java
@@ -54,7 +54,7 @@ public class CooperatorServiceStudentTests extends BaseServiceTest {
     }
 
     @Test
-    public void testCreateStudent1() {
+    public void testCreateStudent() {
         String firstName = "Albert";
         String lastName = "Kragl";
         String email = "frisbeeGod47@gmail.com";
@@ -72,6 +72,40 @@ public class CooperatorServiceStudentTests extends BaseServiceTest {
         assertEquals(s.getEmail(), email);
         assertEquals(s.getStudentId(), studentID);
         assertEquals(1, studentService.getAllStudents().size());
+    }
+
+    @Test
+    public void testStudentUniqueEmail() {
+        String firstName = "Albert";
+        String lastName = "Kragl";
+        String email = "frisbeeGod47@gmail.com";
+        String studentID = "260735111";
+        String studentID2 = "260735112";
+
+        try {
+            studentService.createStudent(firstName, lastName, email, studentID);
+            // email must be unique so expect a SQLException
+            studentService.createStudent(firstName, lastName, email, studentID2);
+        } catch (Exception e) {
+            assertEquals(1, studentService.getAllStudents().size());
+        }
+    }
+
+    @Test
+    public void testStudentUniqueStudentID() {
+        String firstName = "Albert";
+        String lastName = "Kragl";
+        String email = "frisbeeGod47@gmail.com";
+        String email2 = "bighucks6@gmail.com";
+        String studentID = "260735111";
+
+        try {
+            studentService.createStudent(firstName, lastName, email, studentID);
+            // studentID must be unique so expect a SQLException
+            studentService.createStudent(firstName, lastName, email2, studentID);
+        } catch (Exception e) {
+            assertEquals(1, studentService.getAllStudents().size());
+        }
     }
 
     @Test


### PR DESCRIPTION
# Summary

Added unique constraints to model class fields that should always be unique (e.g. emails). Also added service tests that test this out.

## Test Plan

`mvn test` and `mvn failsafe:integration-test`

## Related Issues

closes #122 
