### PR TITLE
[Frontend] Implement ReportSectionConfig functionality

### DIFF
--- a/Backend/src/main/java/ca/mcgill/cooperator/controller/ControllerUtils.java
+++ b/Backend/src/main/java/ca/mcgill/cooperator/controller/ControllerUtils.java
@@ -1143,6 +1143,7 @@ public class ControllerUtils {
                 rsConfig.getId(),
                 rsConfig.getSectionPrompt(),
                 rsConfig.getResponseType(),
+                rsConfig.getQuestionNumber(),
                 rcDto,
                 null,
                 null);

--- a/Backend/src/main/java/ca/mcgill/cooperator/controller/ReportSectionConfigController.java
+++ b/Backend/src/main/java/ca/mcgill/cooperator/controller/ReportSectionConfigController.java
@@ -39,7 +39,7 @@ public class ReportSectionConfigController extends BaseController {
      * @return the ReportSectionConfig with specified ID
      */
     @GetMapping("/{id}")
-    public ReportSectionConfigDto getReportConfigById(@PathVariable int id) {
+    public ReportSectionConfigDto getReportSectionConfigById(@PathVariable int id) {
         return ControllerUtils.convertToDto(reportSectionConfigService.getReportSectionConfig(id));
     }
 
@@ -52,6 +52,16 @@ public class ReportSectionConfigController extends BaseController {
     public List<ReportSectionConfigDto> getAllReportSectionConfigs() {
         return ControllerUtils.convertReportSectionConfigListToDto(
                 reportSectionConfigService.getAllReportSectionConfigs());
+    }
+
+	/**
+     * Returns all ReportSectionConfig response types
+     *
+     * @return an array of all the response types
+     */
+    @GetMapping("/response-types")
+    public List<String> getReportSectionConfigResponseTypes() {
+        return reportSectionConfigService.getAllResponseTypes();
     }
 
     /**
@@ -70,7 +80,10 @@ public class ReportSectionConfigController extends BaseController {
 
         ReportSectionConfig reportSectionConfig =
                 reportSectionConfigService.createReportSectionConfig(
-                        rscDto.getSectionPrompt(), rscDto.getResponseType(), reportConfig);
+                        rscDto.getSectionPrompt(),
+                        rscDto.getResponseType(),
+                        rscDto.getQuestionNumber(),
+                        reportConfig);
 
         return ControllerUtils.convertToDto(reportSectionConfig);
     }
@@ -111,6 +124,7 @@ public class ReportSectionConfigController extends BaseController {
                         rsConfig,
                         rscDto.getSectionPrompt(),
                         rscDto.getResponseType(),
+                        rscDto.getQuestionNumber(),
                         reportConfig,
                         employerReportSections,
                         studentReportSections);

--- a/Backend/src/main/java/ca/mcgill/cooperator/controller/ReportSectionConfigController.java
+++ b/Backend/src/main/java/ca/mcgill/cooperator/controller/ReportSectionConfigController.java
@@ -54,7 +54,7 @@ public class ReportSectionConfigController extends BaseController {
                 reportSectionConfigService.getAllReportSectionConfigs());
     }
 
-	/**
+    /**
      * Returns all ReportSectionConfig response types
      *
      * @return an array of all the response types

--- a/Backend/src/main/java/ca/mcgill/cooperator/dto/ReportSectionConfigDto.java
+++ b/Backend/src/main/java/ca/mcgill/cooperator/dto/ReportSectionConfigDto.java
@@ -7,6 +7,7 @@ public class ReportSectionConfigDto {
     private Integer id;
     private String sectionPrompt;
     private ReportResponseType responseType;
+    private Integer questionNumber;
 
     private ReportConfigDto reportConfig;
     private List<EmployerReportSectionDto> employerReportSections;
@@ -18,12 +19,14 @@ public class ReportSectionConfigDto {
             Integer id,
             String sectionPrompt,
             ReportResponseType responseType,
+            Integer questionNumber,
             ReportConfigDto reportConfig,
             List<EmployerReportSectionDto> employerReportSections,
             List<StudentReportSectionDto> studentReportSections) {
         this.id = id;
         this.sectionPrompt = sectionPrompt;
         this.responseType = responseType;
+        this.questionNumber = questionNumber;
         this.reportConfig = reportConfig;
         this.employerReportSections = employerReportSections;
         this.studentReportSections = studentReportSections;
@@ -49,6 +52,14 @@ public class ReportSectionConfigDto {
 
     public void setResponseType(ReportResponseType responseType) {
         this.responseType = responseType;
+    }
+
+    public Integer getQuestionNumber() {
+        return this.questionNumber;
+    }
+
+    public void setQuestionNumber(Integer questionNumber) {
+        this.questionNumber = questionNumber;
     }
 
     public ReportConfigDto getReportConfig() {

--- a/Backend/src/main/java/ca/mcgill/cooperator/model/ReportSectionConfig.java
+++ b/Backend/src/main/java/ca/mcgill/cooperator/model/ReportSectionConfig.java
@@ -16,6 +16,7 @@ public class ReportSectionConfig {
     @Id @GeneratedValue private int id;
     private String sectionPrompt;
     private ReportResponseType responseType;
+    private int questionNumber;
 
     @ManyToOne(optional = false)
     private ReportConfig reportConfig;
@@ -56,6 +57,14 @@ public class ReportSectionConfig {
 
     public void setResponseType(ReportResponseType responseType) {
         this.responseType = responseType;
+    }
+
+    public int getQuestionNumber() {
+        return this.questionNumber;
+    }
+
+    public void setQuestionNumber(int questionNumber) {
+        this.questionNumber = questionNumber;
     }
 
     public ReportConfig getReportConfig() {

--- a/Backend/src/main/java/ca/mcgill/cooperator/service/CoopDetailsService.java
+++ b/Backend/src/main/java/ca/mcgill/cooperator/service/CoopDetailsService.java
@@ -6,7 +6,6 @@ import ca.mcgill.cooperator.dao.EmployerContactRepository;
 import ca.mcgill.cooperator.model.Coop;
 import ca.mcgill.cooperator.model.CoopDetails;
 import ca.mcgill.cooperator.model.EmployerContact;
-
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;

--- a/Backend/src/main/java/ca/mcgill/cooperator/service/CoopDetailsService.java
+++ b/Backend/src/main/java/ca/mcgill/cooperator/service/CoopDetailsService.java
@@ -6,6 +6,8 @@ import ca.mcgill.cooperator.dao.EmployerContactRepository;
 import ca.mcgill.cooperator.model.Coop;
 import ca.mcgill.cooperator.model.CoopDetails;
 import ca.mcgill.cooperator.model.EmployerContact;
+
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -101,7 +103,7 @@ public class CoopDetailsService extends BaseService {
         coopRepository.save(c);
 
         EmployerContact ec = cd.getEmployerContact();
-        Set<CoopDetails> details = ec.getCoopDetails();
+        Set<CoopDetails> details = new HashSet<>(ec.getCoopDetails());
         details.remove(cd);
         ec.setCoopDetails(details);
         employerContactRepository.save(ec);

--- a/Backend/src/main/java/ca/mcgill/cooperator/service/ReportSectionConfigService.java
+++ b/Backend/src/main/java/ca/mcgill/cooperator/service/ReportSectionConfigService.java
@@ -7,6 +7,7 @@ import ca.mcgill.cooperator.model.ReportConfig;
 import ca.mcgill.cooperator.model.ReportResponseType;
 import ca.mcgill.cooperator.model.ReportSectionConfig;
 import ca.mcgill.cooperator.model.StudentReportSection;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -30,13 +31,19 @@ public class ReportSectionConfigService extends BaseService {
      */
     @Transactional
     public ReportSectionConfig createReportSectionConfig(
-            String sectionPrompt, ReportResponseType responseType, ReportConfig reportConfig) {
+            String sectionPrompt,
+            ReportResponseType responseType,
+            int questionNumber,
+            ReportConfig reportConfig) {
         StringBuilder error = new StringBuilder();
         if (sectionPrompt == null || sectionPrompt.trim().length() == 0) {
             error.append("Section prompt cannot be empty! ");
         }
         if (responseType == null) {
             error.append("Response type cannot be null! ");
+        }
+        if (questionNumber <= 0) {
+            error.append("Question number cannot be less than 1! ");
         }
         if (reportConfig == null) {
             error.append("Report config cannot be null!");
@@ -48,6 +55,7 @@ public class ReportSectionConfigService extends BaseService {
         ReportSectionConfig rsConfig = new ReportSectionConfig();
         rsConfig.setSectionPrompt(sectionPrompt);
         rsConfig.setResponseType(responseType);
+        rsConfig.setQuestionNumber(questionNumber);
         rsConfig.setReportConfig(reportConfig);
         rsConfig.setEmployerReportSections(new HashSet<EmployerReportSection>());
         rsConfig.setStudentReportSections(new HashSet<StudentReportSection>());
@@ -83,6 +91,23 @@ public class ReportSectionConfigService extends BaseService {
     }
 
     /**
+     * Returns all ReportSectionConfig response types
+     *
+     * @return an array of all the response types
+     */
+    @Transactional
+    public List<String> getAllResponseTypes() {
+        ReportResponseType[] responseTypes = ReportResponseType.values();
+        List<String> responseTypeStrings = new ArrayList<>(responseTypes.length);
+
+        for (ReportResponseType rt : responseTypes) {
+            responseTypeStrings.add(rt.name());
+        }
+
+        return responseTypeStrings;
+    }
+
+    /**
      * Updates an existing ReportSectionConfig
      *
      * @param rsConfig
@@ -98,6 +123,7 @@ public class ReportSectionConfigService extends BaseService {
             ReportSectionConfig rsConfig,
             String sectionPrompt,
             ReportResponseType responseType,
+            Integer questionNumber,
             ReportConfig reportConfig,
             Set<EmployerReportSection> employerReportSections,
             Set<StudentReportSection> studentReportSections) {
@@ -108,6 +134,9 @@ public class ReportSectionConfigService extends BaseService {
         if (sectionPrompt != null && sectionPrompt.trim().length() == 0) {
             error.append("Section prompt cannot be empty! ");
         }
+        if (questionNumber != null && questionNumber <= 0) {
+            error.append("Question number cannot be less than 1!");
+        }
         if (error.length() > 0) {
             throw new IllegalArgumentException(ERROR_PREFIX + error.toString().trim());
         }
@@ -117,6 +146,9 @@ public class ReportSectionConfigService extends BaseService {
         }
         if (responseType != null) {
             rsConfig.setResponseType(responseType);
+        }
+        if (questionNumber != null) {
+            rsConfig.setQuestionNumber(questionNumber);
         }
         if (reportConfig != null) {
             rsConfig.setReportConfig(reportConfig);
@@ -150,6 +182,15 @@ public class ReportSectionConfigService extends BaseService {
         rsConfigs.remove(rsConfig);
         reportConfig.setReportSectionConfigs(rsConfigs);
         reportConfigRepository.save(reportConfig);
+        
+        // update question numbers of other ReportSectionConfigs
+        List<ReportSectionConfig> allReportSectionConfigs = getAllReportSectionConfigs();
+        for (ReportSectionConfig rsc : allReportSectionConfigs) {
+        	if (rsc.getQuestionNumber() > rsConfig.getQuestionNumber()) {
+        		// lower question number by 1
+        		updateReportSectionConfig(rsc, null, null, rsc.getQuestionNumber()-1, null, null, null);
+        	}
+        }
 
         reportSectionConfigRepository.delete(rsConfig);
         return rsConfig;

--- a/Backend/src/main/java/ca/mcgill/cooperator/service/ReportSectionConfigService.java
+++ b/Backend/src/main/java/ca/mcgill/cooperator/service/ReportSectionConfigService.java
@@ -8,7 +8,6 @@ import ca.mcgill.cooperator.model.ReportResponseType;
 import ca.mcgill.cooperator.model.ReportSectionConfig;
 import ca.mcgill.cooperator.model.StudentReportSection;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -183,17 +182,18 @@ public class ReportSectionConfigService extends BaseService {
         rsConfigs.remove(rsConfig);
         reportConfig.setReportSectionConfigs(rsConfigs);
         reportConfigRepository.save(reportConfig);
-        
+
         // update question numbers of other ReportSectionConfigs
         List<ReportSectionConfig> allReportSectionConfigs = getAllReportSectionConfigs();
         for (ReportSectionConfig rsc : allReportSectionConfigs) {
-        	if (rsc.getQuestionNumber() > rsConfig.getQuestionNumber()) {
-        		// lower question number by 1
-        		updateReportSectionConfig(rsc, null, null, rsc.getQuestionNumber()-1, null, null, null);
-        	}
+            if (rsc.getQuestionNumber() > rsConfig.getQuestionNumber()) {
+                // lower question number by 1
+                updateReportSectionConfig(
+                        rsc, null, null, rsc.getQuestionNumber() - 1, null, null, null);
+            }
         }
 
-        //reportSectionConfigRepository.delete(rsConfig);
+        // reportSectionConfigRepository.delete(rsConfig);
         return rsConfig;
     }
 }

--- a/Backend/src/main/java/ca/mcgill/cooperator/service/ReportSectionConfigService.java
+++ b/Backend/src/main/java/ca/mcgill/cooperator/service/ReportSectionConfigService.java
@@ -193,7 +193,7 @@ public class ReportSectionConfigService extends BaseService {
             }
         }
 
-        // reportSectionConfigRepository.delete(rsConfig);
+        reportSectionConfigRepository.delete(rsConfig);
         return rsConfig;
     }
 }

--- a/Backend/src/main/java/ca/mcgill/cooperator/service/ReportSectionConfigService.java
+++ b/Backend/src/main/java/ca/mcgill/cooperator/service/ReportSectionConfigService.java
@@ -8,6 +8,7 @@ import ca.mcgill.cooperator.model.ReportResponseType;
 import ca.mcgill.cooperator.model.ReportSectionConfig;
 import ca.mcgill.cooperator.model.StudentReportSection;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -178,7 +179,7 @@ public class ReportSectionConfigService extends BaseService {
 
         // first delete from parent ReportConfig
         ReportConfig reportConfig = rsConfig.getReportConfig();
-        Set<ReportSectionConfig> rsConfigs = reportConfig.getReportSectionConfigs();
+        Set<ReportSectionConfig> rsConfigs = new HashSet<>(reportConfig.getReportSectionConfigs());
         rsConfigs.remove(rsConfig);
         reportConfig.setReportSectionConfigs(rsConfigs);
         reportConfigRepository.save(reportConfig);
@@ -192,7 +193,7 @@ public class ReportSectionConfigService extends BaseService {
         	}
         }
 
-        reportSectionConfigRepository.delete(rsConfig);
+        //reportSectionConfigRepository.delete(rsConfig);
         return rsConfig;
     }
 }

--- a/Backend/src/test/java/ca/mcgill/cooperator/service/BaseServiceTest.java
+++ b/Backend/src/test/java/ca/mcgill/cooperator/service/BaseServiceTest.java
@@ -155,6 +155,6 @@ public class BaseServiceTest {
             ReportSectionConfigService rscService,
             ReportConfig reportConfig) {
         return rscService.createReportSectionConfig(
-                "How was your co-op?", ReportResponseType.LONG_TEXT, reportConfig);
+                "How was your co-op?", ReportResponseType.LONG_TEXT, 1, reportConfig);
     }
 }

--- a/Backend/src/test/java/ca/mcgill/cooperator/service/CooperatorServiceReportSectionConfigTests.java
+++ b/Backend/src/test/java/ca/mcgill/cooperator/service/CooperatorServiceReportSectionConfigTests.java
@@ -63,6 +63,7 @@ public class CooperatorServiceReportSectionConfigTests extends BaseServiceTest {
                     ERROR_PREFIX
                             + "Section prompt cannot be empty! "
                             + "Response type cannot be null! "
+                            + "Question number cannot be less than 1! "
                             + "Report config cannot be null!",
                     e.getMessage());
         }
@@ -141,7 +142,8 @@ public class CooperatorServiceReportSectionConfigTests extends BaseServiceTest {
             assertEquals(
                     ERROR_PREFIX
                             + "Report section config to update cannot be null! "
-                            + "Section prompt cannot be empty!",
+                            + "Section prompt cannot be empty! "
+                            + "Question number cannot be less than 1!",
                     e.getMessage());
         }
 

--- a/Backend/src/test/java/ca/mcgill/cooperator/service/CooperatorServiceReportSectionConfigTests.java
+++ b/Backend/src/test/java/ca/mcgill/cooperator/service/CooperatorServiceReportSectionConfigTests.java
@@ -135,7 +135,8 @@ public class CooperatorServiceReportSectionConfigTests extends BaseServiceTest {
 
         // 2. invalid updates
         try {
-            reportSectionConfigService.updateReportSectionConfig(null, " ", null, -1, null, null, null);
+            reportSectionConfigService.updateReportSectionConfig(
+                    null, " ", null, -1, null, null, null);
         } catch (IllegalArgumentException e) {
             assertEquals(
                     ERROR_PREFIX

--- a/Backend/src/test/java/ca/mcgill/cooperator/service/CooperatorServiceReportSectionConfigTests.java
+++ b/Backend/src/test/java/ca/mcgill/cooperator/service/CooperatorServiceReportSectionConfigTests.java
@@ -41,7 +41,7 @@ public class CooperatorServiceReportSectionConfigTests extends BaseServiceTest {
         try {
             ReportConfig rc = createTestReportConfig(reportConfigService, "First Evaluation");
             reportSectionConfigService.createReportSectionConfig(
-                    prompt, ReportResponseType.LONG_TEXT, rc);
+                    prompt, ReportResponseType.LONG_TEXT, 1, rc);
         } catch (IllegalArgumentException e) {
             fail();
         }
@@ -57,7 +57,7 @@ public class CooperatorServiceReportSectionConfigTests extends BaseServiceTest {
     @Test
     public void testCreateReportSectionConfigInvalid() {
         try {
-            reportSectionConfigService.createReportSectionConfig("  ", null, null);
+            reportSectionConfigService.createReportSectionConfig("  ", null, -1, null);
         } catch (IllegalArgumentException e) {
             assertEquals(
                     ERROR_PREFIX
@@ -79,7 +79,7 @@ public class CooperatorServiceReportSectionConfigTests extends BaseServiceTest {
             rc = createTestReportConfig(reportConfigService, "First Evaluation");
             rsConfig =
                     reportSectionConfigService.createReportSectionConfig(
-                            prompt, ReportResponseType.LONG_TEXT, rc);
+                            prompt, ReportResponseType.LONG_TEXT, 1, rc);
         } catch (IllegalArgumentException e) {
             fail();
         }
@@ -88,7 +88,7 @@ public class CooperatorServiceReportSectionConfigTests extends BaseServiceTest {
         prompt = "Which tools did you use during your co-op?";
         try {
             reportSectionConfigService.updateReportSectionConfig(
-                    rsConfig, prompt, null, null, null, null);
+                    rsConfig, prompt, null, null, null, null, null);
         } catch (IllegalArgumentException e) {
             fail();
         }
@@ -108,7 +108,7 @@ public class CooperatorServiceReportSectionConfigTests extends BaseServiceTest {
                             rc, null, null, null, "Second Evaluation", null);
 
             reportSectionConfigService.updateReportSectionConfig(
-                    rsConfig, prompt, ReportResponseType.SHORT_TEXT, null, null, null);
+                    rsConfig, prompt, ReportResponseType.SHORT_TEXT, 2, null, null, null);
         } catch (IllegalArgumentException e) {
             fail();
         }
@@ -128,14 +128,14 @@ public class CooperatorServiceReportSectionConfigTests extends BaseServiceTest {
         try {
             ReportConfig rc = createTestReportConfig(reportConfigService, "First Evaluation");
             reportSectionConfigService.createReportSectionConfig(
-                    prompt, ReportResponseType.LONG_TEXT, rc);
+                    prompt, ReportResponseType.LONG_TEXT, 1, rc);
         } catch (IllegalArgumentException e) {
             fail();
         }
 
         // 2. invalid updates
         try {
-            reportSectionConfigService.updateReportSectionConfig(null, " ", null, null, null, null);
+            reportSectionConfigService.updateReportSectionConfig(null, " ", null, -1, null, null, null);
         } catch (IllegalArgumentException e) {
             assertEquals(
                     ERROR_PREFIX
@@ -161,7 +161,7 @@ public class CooperatorServiceReportSectionConfigTests extends BaseServiceTest {
             ReportConfig rc = createTestReportConfig(reportConfigService, "First Evaluation");
             ReportSectionConfig rsc =
                     reportSectionConfigService.createReportSectionConfig(
-                            prompt, ReportResponseType.LONG_TEXT, rc);
+                            prompt, ReportResponseType.LONG_TEXT, 1, rc);
 
             reportSectionConfigService.deleteReportSectionConfig(rsc);
         } catch (IllegalArgumentException e) {

--- a/Frontend/src/components/admin/ReportConfigurationItem.vue
+++ b/Frontend/src/components/admin/ReportConfigurationItem.vue
@@ -43,9 +43,9 @@ Parent: AdminReportConfigPage.vue -->
         <div v-if="rsConfigs.length > 0">
           <ReportSectionConfigurationItem
             v-for="rsConfig in rsConfigs"
-            :key="rsConfig.sectionPrompt"
-            :prompt="rsConfig.sectionPrompt"
-            :responseType="rsConfig.responseType"
+            :key="rsConfig.id"
+            :reportSectionConfig="rsConfig"
+            @refresh="notifyParent"
           />
         </div>
         <div v-else class="text-body2">
@@ -108,6 +108,7 @@ export default {
       showEditPopup: false,
       showDeletePopup: false,
       showReportSectionConfigPopup: false,
+      editingReportSection: false,
       rsConfigs: []
     };
   },
@@ -142,6 +143,9 @@ export default {
   methods: {
     notifyParent: function() {
       this.$emit("refresh");
+    },
+    handleReportSectionEdit: function(id) {
+      this.editingReportSection = true;
     },
     compareReportSectionConfigs: function(rsc1, rsc2) {
       // used to sort report section configs by question number

--- a/Frontend/src/components/admin/ReportConfigurationItem.vue
+++ b/Frontend/src/components/admin/ReportConfigurationItem.vue
@@ -28,7 +28,13 @@ Parent: AdminReportConfigPage.vue -->
           <div class="col-7">Section Prompt</div>
           <div class="col-3">Response Type</div>
           <div class="col-2">
-            <q-btn label="+ New" color="primary" class="align-right" flat />
+            <q-btn
+              label="+ New"
+              color="primary"
+              class="align-right"
+              flat
+              @click="showReportSectionConfigPopup = true"
+            />
           </div>
         </div>
 
@@ -37,8 +43,8 @@ Parent: AdminReportConfigPage.vue -->
         <div v-if="rsConfigs.length > 0">
           <ReportSectionConfigurationItem
             v-for="rsConfig in rsConfigs"
-            :key="rsConfig.prompt"
-            :prompt="rsConfig.prompt"
+            :key="rsConfig.sectionPrompt"
+            :prompt="rsConfig.sectionPrompt"
             :responseType="rsConfig.responseType"
           />
         </div>
@@ -71,6 +77,14 @@ Parent: AdminReportConfigPage.vue -->
       <q-dialog v-model="showDeletePopup">
         <ReportConfigurationDeletePopup :id="this.id" @refresh="notifyParent" />
       </q-dialog>
+
+      <q-dialog v-model="showReportSectionConfigPopup">
+        <ReportSectionConfigurationPopup
+          :reportConfigId="this.id"
+          :numberOfQuestions="this.rsConfigs.length"
+          @refresh="notifyParent"
+        />
+      </q-dialog>
     </q-card-section>
   </q-card>
 </template>
@@ -79,19 +93,22 @@ Parent: AdminReportConfigPage.vue -->
 import ReportConfigurationPopup from "./ReportConfigurationPopup";
 import ReportConfigurationDeletePopup from "./ReportConfigurationDeletePopup.vue";
 import ReportSectionConfigurationItem from "./ReportSectionConfigurationItem.vue";
+import ReportSectionConfigurationPopup from "./ReportSectionConfigurationPopup.vue";
 
 export default {
   name: "ReportConfigurationItem",
   components: {
     ReportConfigurationPopup,
     ReportConfigurationDeletePopup,
-    ReportSectionConfigurationItem
+    ReportSectionConfigurationItem,
+    ReportSectionConfigurationPopup
   },
   data: function() {
     return {
       showEditPopup: false,
       showDeletePopup: false,
-      rsConfigs: this.reportSectionConfigs
+      showReportSectionConfigPopup: false,
+      rsConfigs: []
     };
   },
   props: {
@@ -125,7 +142,16 @@ export default {
   methods: {
     notifyParent: function() {
       this.$emit("refresh");
+    },
+    compareReportSectionConfigs: function(rsc1, rsc2) {
+      // used to sort report section configs by question number
+      return rsc1.questionNumber - rsc2.questionNumber;
     }
+  },
+  created: function() {
+    this.rsConfigs = this.reportSectionConfigs.sort(
+      this.compareReportSectionConfigs
+    );
   }
 };
 </script>

--- a/Frontend/src/components/admin/ReportConfigurationPopup.vue
+++ b/Frontend/src/components/admin/ReportConfigurationPopup.vue
@@ -1,5 +1,6 @@
 <!-- This component is a popup for both creating and editing a report config.
-It is rendered slightly differently depending on whether it is in editing mode or not.
+It is rendered slightly differently depending on whether it is in editing mode
+or not.
 
 Parent: AdminReportConfigPage.vue -->
 <template>

--- a/Frontend/src/components/admin/ReportConfigurationPopup.vue
+++ b/Frontend/src/components/admin/ReportConfigurationPopup.vue
@@ -57,8 +57,9 @@ Parent: AdminReportConfigPage.vue -->
 
         <q-btn color="primary" type="submit" :label="buttonLabel" />
       </q-form>
-    </q-card-section> </q-card
-></template>
+    </q-card-section>
+  </q-card>
+</template>
 
 <script>
 export default {

--- a/Frontend/src/components/admin/ReportSectionConfigurationItem.vue
+++ b/Frontend/src/components/admin/ReportSectionConfigurationItem.vue
@@ -4,25 +4,44 @@ report configuration.
 Parent: ReportConfigurationItem.vue -->
 <template>
   <div class="row">
-    <div class="col-7 text-body2">{{ prompt }}</div>
-    <div class="col-4 text-body2">{{ responseType }}</div>
+    <div class="col-7 text-body2">{{ reportSectionConfig.sectionPrompt }}</div>
+    <div class="col-4 text-body2">{{ reportSectionConfig.responseType }}</div>
     <div class="col-1">
-      <q-btn label="Edit" color="primary" flat />
+      <q-btn label="Edit" color="primary" flat @click="showPopup = true" />
     </div>
+
+    <q-dialog v-model="showPopup">
+      <ReportSectionConfigurationPopup
+        :isEditing="true"
+        :reportSectionConfig="this.reportSectionConfig"
+        @refresh="notifyParent"
+      />
+    </q-dialog>
   </div>
 </template>
 
 <script>
+import ReportSectionConfigurationPopup from "./ReportSectionConfigurationPopup.vue";
+
 export default {
   name: "ReportSectionConfigurationItem",
+  components: {
+    ReportSectionConfigurationPopup
+  },
+  data: function() {
+    return {
+      showPopup: false
+    };
+  },
   props: {
-    prompt: {
-      type: String,
+    reportSectionConfig: {
+      type: Object,
       required: true
-    },
-    responseType: {
-      type: String,
-      required: true
+    }
+  },
+  methods: {
+    notifyParent: function() {
+      this.$emit("refresh");
     }
   }
 };

--- a/Frontend/src/components/admin/ReportSectionConfigurationPopup.vue
+++ b/Frontend/src/components/admin/ReportSectionConfigurationPopup.vue
@@ -26,6 +26,13 @@
         />
 
         <q-btn color="primary" type="submit" :label="buttonLabel" />
+        <q-btn
+          v-if="isEditing"
+          color="primary"
+          label="Delete"
+          flat
+          @click="deleteReportSectionConfig"
+        />
       </q-form>
     </q-card-section>
   </q-card>
@@ -43,17 +50,24 @@ export default {
     };
   },
   props: {
-    reportConfigId: {
-      type: Number,
+    reportSectionConfig: {
+      type: Object,
       required: true
     },
-    numberOfQuestions: {
-      type: Number,
-      required: true
-    },
-    prompt: String,
-    responseType: String,
+    numberOfQuestions: Number,
     isEditing: Boolean
+  },
+  created: function() {
+    this.$axios.get("/report-section-configs/response-types").then(resp => {
+      this.options = resp.data;
+    });
+
+    if (this.isEditing) {
+      this.popupTitle = "Edit Report Section Configuration";
+      this.promptData = this.reportSectionConfig.sectionPrompt;
+      this.responseTypeData = this.reportSectionConfig.responseType;
+      this.buttonLabel = "Update";
+    }
   },
   methods: {
     onSubmit: function() {
@@ -96,18 +110,59 @@ export default {
           });
         });
     },
-    updateReportSectionConfig: function() {}
-  },
-  created: function() {
-    this.$axios.get("/report-section-configs/response-types").then(resp => {
-      this.options = resp.data;
-    });
+    updateReportSectionConfig: function() {
+      const body = {
+        id: this.reportSectionConfig.id,
+        sectionPrompt: this.promptData,
+        responseType: this.responseTypeData
+      };
 
-    if (this.isEditing) {
-      this.popupTitle = "Edit Report Section Configuration";
-      this.promptData = this.prompt;
-      this.responseTypeData = this.responseType;
-      this.buttonLabel = "Update";
+      this.$axios
+        .put("/report-section-configs", body)
+        .then(_resp => {
+          this.$q.notify({
+            color: "green-4",
+            position: "top",
+            textColor: "white",
+            icon: "cloud_done",
+            message: "Updated Successfully"
+          });
+          // let parent know to close the dialog and refresh its list of report configs
+          this.$emit("refresh");
+        })
+        .catch(_err => {
+          this.$q.notify({
+            color: "red-4",
+            position: "top",
+            textColor: "white",
+            icon: "error",
+            message: "Something went wrong, please try again"
+          });
+        });
+    },
+    deleteReportSectionConfig: function() {
+      this.$axios
+        .delete("/report-section-configs/" + this.reportSectionConfig.id)
+        .then(_resp => {
+          this.$q.notify({
+            color: "green-4",
+            position: "top",
+            textColor: "white",
+            icon: "cloud_done",
+            message: "Deleted Successfully"
+          });
+          // let parent know to close the dialog and refresh its list of report configs
+          this.$emit("refresh");
+        })
+        .catch(_err => {
+          this.$q.notify({
+            color: "red-4",
+            position: "top",
+            textColor: "white",
+            icon: "error",
+            message: "Something went wrong, please try again"
+          });
+        });
     }
   }
 };

--- a/Frontend/src/components/admin/ReportSectionConfigurationPopup.vue
+++ b/Frontend/src/components/admin/ReportSectionConfigurationPopup.vue
@@ -1,0 +1,116 @@
+<template>
+  <q-card id="card">
+    <q-card-section class="row items-center">
+      <div class="text-h6">{{ popupTitle }}</div>
+      <q-space />
+      <q-btn icon="close" flat round dense v-close-popup />
+    </q-card-section>
+
+    <q-card-section>
+      <q-form @submit="onSubmit" class="q-gutter-sm">
+        <q-input
+          filled
+          v-model="promptData"
+          type="textarea"
+          label="Section Prompt (e.g. How was your co-op?)"
+          lazy-rules
+          :rules="[val => (val && val.length > 0) || 'Please enter a prompt']"
+        />
+
+        <q-select
+          filled
+          v-model="responseTypeData"
+          label="Response Type"
+          :options="options"
+          class="col-6"
+        />
+
+        <q-btn color="primary" type="submit" :label="buttonLabel" />
+      </q-form>
+    </q-card-section>
+  </q-card>
+</template>
+
+<script>
+export default {
+  data: function() {
+    return {
+      popupTitle: "Add New Report Section Configuration",
+      promptData: "",
+      responseTypeData: "",
+      buttonLabel: "Create",
+      options: []
+    };
+  },
+  props: {
+    reportConfigId: {
+      type: Number,
+      required: true
+    },
+    numberOfQuestions: {
+      type: Number,
+      required: true
+    },
+    prompt: String,
+    responseType: String,
+    isEditing: Boolean
+  },
+  methods: {
+    onSubmit: function() {
+      if (this.isEditing) {
+        this.updateReportSectionConfig();
+      } else {
+        this.createReportSectionConfig();
+      }
+    },
+    createReportSectionConfig: function() {
+      const body = {
+        sectionPrompt: this.promptData,
+        responseType: this.responseTypeData,
+        questionNumber: this.numberOfQuestions + 1,
+        reportConfig: {
+          id: this.reportConfigId
+        }
+      };
+
+      this.$axios
+        .post("/report-section-configs", body)
+        .then(_resp => {
+          this.$q.notify({
+            color: "green-4",
+            position: "top",
+            textColor: "white",
+            icon: "cloud_done",
+            message: "Created Successfully"
+          });
+          // let parent know to close the dialog and refresh its list of report configs
+          this.$emit("refresh");
+        })
+        .catch(_err => {
+          this.$q.notify({
+            color: "red-4",
+            position: "top",
+            textColor: "white",
+            icon: "error",
+            message: "Something went wrong, please try again"
+          });
+        });
+    },
+    updateReportSectionConfig: function() {}
+  },
+  created: function() {
+    this.$axios.get("/report-section-configs/response-types").then(resp => {
+      this.options = resp.data;
+    });
+
+    if (this.isEditing) {
+      this.popupTitle = "Edit Report Section Configuration";
+      this.promptData = this.prompt;
+      this.responseTypeData = this.responseType;
+      this.buttonLabel = "Update";
+    }
+  }
+};
+</script>
+
+<style lang="scss" scoped></style>

--- a/Frontend/src/components/admin/ReportSectionConfigurationPopup.vue
+++ b/Frontend/src/components/admin/ReportSectionConfigurationPopup.vue
@@ -1,3 +1,8 @@
+<!-- This component is a popup for both creating and editing a report section
+config. It is rendered slightly differently depending on whether it is in
+editing mode or not.
+
+Parent: ReportSectionConfigurationItem.vue -->
 <template>
   <q-card id="card">
     <q-card-section class="row items-center">

--- a/Frontend/src/pages/admin/AdminReportConfigPage.vue
+++ b/Frontend/src/pages/admin/AdminReportConfigPage.vue
@@ -83,6 +83,7 @@ export default {
     refreshList: function() {
       this.showPopup = false;
       this.showDeletePopup = false;
+
       this.loading = true;
       this.$axios.get("/report-configs").then(resp => {
         this.reportConfigs = resp.data;

--- a/Frontend/src/pages/student/StudentAddNewCoop.vue
+++ b/Frontend/src/pages/student/StudentAddNewCoop.vue
@@ -107,9 +107,6 @@ export default {
       this.$axios
         .post("/coops", coop)
         .then(resp => {
-          console.log(resp);
-          console.log("Coop created");
-
           // after coop is created, POST request for offer letter
           const formData = new FormData();
           formData.append("file", this.offerLetterFile);
@@ -122,8 +119,6 @@ export default {
               headers: { "Content-Type": "multipart/form-data" }
             })
             .then(resp => {
-              console.log(resp);
-              console.log("Report (offer letter) created");
               this.submitting = false;
 
               this.$router.push({ path: "/student/home" });
@@ -140,7 +135,7 @@ export default {
 };
 </script>
 
-<style scoped lang="scss">
+<style lang="scss" scoped>
 #container {
   width: 75%;
 }


### PR DESCRIPTION
# Summary

Added more functionality to the Admin's ReportConfig page by implementing the features for ReportSectionConfigs (creating, updating, and deleting them).

Also added a new field called `questionNumber` to ReportSectionConfig in the backend—this allows us to know the order in which questions should appear for a report.

## Test Plan

`mvn test` for backend changes

![Screen Shot 2020-03-24 at  Mar 24   5 13 06 PM](https://user-images.githubusercontent.com/25532617/77477628-05cca680-6df3-11ea-8d7b-83044989babb.jpg)
![Screen Shot 2020-03-24 at  Mar 24   5 13 15 PM](https://user-images.githubusercontent.com/25532617/77477637-09602d80-6df3-11ea-8fa1-0218fd8db4e6.jpg)
![Screen Shot 2020-03-24 at  Mar 24   5 15 31 PM](https://user-images.githubusercontent.com/25532617/77477680-1846e000-6df3-11ea-99a8-88c17a11d3ee.jpg)

## Related Issues

closes #119 
