### PR TITLE
Add course name input to new Coop page for Student

### DIFF
--- a/Backend/src/main/java/ca/mcgill/cooperator/controller/CoopController.java
+++ b/Backend/src/main/java/ca/mcgill/cooperator/controller/CoopController.java
@@ -91,7 +91,7 @@ public class CoopController extends BaseController {
         if (courseOfferingDto.getId() > 0) {
             courseOffering = courseOfferingService.getCourseOfferingById(courseOfferingDto.getId());
         } else {
-        	// if no ID present, get CourseOffering via Course
+            // if no ID present, get CourseOffering via Course
             String courseName = courseOfferingDto.getCourse().getName();
             Course course = courseService.getCourseByName(courseName);
 
@@ -100,7 +100,7 @@ public class CoopController extends BaseController {
                             course, courseOfferingDto.getYear(), courseOfferingDto.getSeason());
 
             if (courseOffering == null) {
-            	// create the CourseOffering if it doesn't already exist
+                // create the CourseOffering if it doesn't already exist
                 courseOffering =
                         courseOfferingService.createCourseOffering(
                                 courseOfferingDto.getYear(), courseOfferingDto.getSeason(), course);

--- a/Backend/src/main/java/ca/mcgill/cooperator/controller/CoopController.java
+++ b/Backend/src/main/java/ca/mcgill/cooperator/controller/CoopController.java
@@ -91,12 +91,8 @@ public class CoopController extends BaseController {
         if (courseOfferingDto.getId() > 0) {
             courseOffering = courseOfferingService.getCourseOfferingById(courseOfferingDto.getId());
         } else {
-            // we need to derive the Course Offering if ID is not given
-
-            // this is a bit hacky, but if they have 0 co-ops already (for example) then this
-            // is their first co-op term and they should be taking FACC 200
-            String courseName = "FACC 20" + student.getCoops().size();
-            // all courses (FACC 200-205) should always exist
+        	// if no ID present, get CourseOffering via Course
+            String courseName = courseOfferingDto.getCourse().getName();
             Course course = courseService.getCourseByName(courseName);
 
             courseOffering =
@@ -104,6 +100,7 @@ public class CoopController extends BaseController {
                             course, courseOfferingDto.getYear(), courseOfferingDto.getSeason());
 
             if (courseOffering == null) {
+            	// create the CourseOffering if it doesn't already exist
                 courseOffering =
                         courseOfferingService.createCourseOffering(
                                 courseOfferingDto.getYear(), courseOfferingDto.getSeason(), course);

--- a/Frontend/src/pages/student/StudentAddNewCoop.vue
+++ b/Frontend/src/pages/student/StudentAddNewCoop.vue
@@ -109,9 +109,9 @@ export default {
     };
   },
   created: function() {
-    this.$axios.get("/courses").then(resp => {
-      resp.data.forEach(course => {
-        this.courseNameOptions.push(course.name);
+    this.$axios.get("/courses/names").then(resp => {
+      resp.data.forEach(name => {
+        this.courseNameOptions.push(name);
         this.loading = false;
       });
     });


### PR DESCRIPTION
# Summary

This PR gets rid of the hacky way that the course name was derived in the Coop controller when a Student submitted a new Coop. Now they can directly input the course name instead, and course names are fetched from the backend.

## Test Plan

Created a co-op from this page and checked that it was created properly

![Screen Shot 2020-03-26 at  Mar 26   11 18 21 PM](https://user-images.githubusercontent.com/25532617/77717993-24c86580-6fb8-11ea-8836-f5448c1ad472.jpg)

## Related Issues

N/A
