### PR TITLE
Add dark mode to frontend

### DIFF
--- a/Frontend/quasar.conf.js
+++ b/Frontend/quasar.conf.js
@@ -6,7 +6,7 @@ module.exports = function(ctx) {
     // app boot file (/src/boot)
     // --> boot files are part of "main.js"
     // https://quasar.dev/quasar-cli/cli-documentation/boot-files
-    boot: ["axios","clipboard", "common"],
+    boot: ["axios", "clipboard", "common"],
 
     // https://quasar.dev/quasar-cli/quasar-conf-js#Property%3A-css
     css: ["app.scss"],
@@ -42,7 +42,7 @@ module.exports = function(ctx) {
       directives: [],
 
       // Quasar plugins
-      plugins: ["Notify"]
+      plugins: ["LocalStorage", "Notify"]
     },
 
     // https://quasar.dev/quasar-cli/cli-documentation/supporting-ie

--- a/Frontend/src/layouts/AdminLoggedInLayout.vue
+++ b/Frontend/src/layouts/AdminLoggedInLayout.vue
@@ -24,7 +24,20 @@
 
         <q-btn flat dense round icon="settings" aria-label="Settings">
           <q-menu>
-            <q-list style="min-width: 100px">
+            <q-list style="min-width: 200px">
+              <q-item>
+                <q-item-section>
+                  <q-item-label>Dark Mode</q-item-label>
+                </q-item-section>
+                <q-item-section side top>
+                  <q-toggle
+                    color="white"
+                    v-model="darkModeOn"
+                    val="picture"
+                    @input="setDarkMode"
+                  />
+                </q-item-section>
+              </q-item>
               <q-item clickable v-close-popup>
                 <q-item-section>username</q-item-section>
               </q-item>
@@ -44,7 +57,7 @@
       </q-toolbar>
     </q-header>
 
-    <q-drawer v-model="leftDrawerOpen" bordered content-class="bg-grey-1">
+    <q-drawer v-model="leftDrawerOpen" bordered>
       <q-list>
         <q-item-label header class="text-grey-8">Navigation</q-item-label>
         <SidebarLink
@@ -97,14 +110,26 @@
 import SidebarLink from "../components/SidebarLink.vue";
 
 export default {
-  name: "LoggedInLayout",
+  name: "AdminLoggedInLayout",
   components: {
     SidebarLink
   },
   data() {
     return {
-      leftDrawerOpen: false
+      leftDrawerOpen: false,
+      darkModeOn: this.$q.localStorage.getItem("darkMode")
     };
+  },
+  created: function() {
+    this.setDarkMode();
+  },
+  methods: {
+    setDarkMode: function() {
+      if (this.darkModeOn === null) this.darkModeOn = false;
+
+      this.$q.dark.set(this.darkModeOn);
+      this.$q.localStorage.set("darkMode", this.darkModeOn);
+    }
   }
 };
 </script>

--- a/Frontend/src/layouts/StudentLoggedInLayout.vue
+++ b/Frontend/src/layouts/StudentLoggedInLayout.vue
@@ -30,7 +30,21 @@
 
         <q-btn flat dense round icon="settings" aria-label="Settings">
           <q-menu>
-            <q-list style="min-width: 125px">
+            <q-list style="min-width: 200px">
+              <q-item>
+                <q-item-section>
+                  <q-item-label>Dark Mode</q-item-label>
+                </q-item-section>
+                <q-item-section side top>
+                  <q-toggle
+                    color="white"
+                    v-model="darkModeOn"
+                    val="picture"
+                    @input="setDarkMode"
+                  />
+                </q-item-section>
+              </q-item>
+              <q-separator />
               <q-item clickable v-close-popup>
                 <q-item-section>Settings</q-item-section>
               </q-item>
@@ -43,7 +57,7 @@
       </q-toolbar>
     </q-header>
 
-    <q-drawer v-model="leftDrawerOpen" bordered content-class="bg-grey-1">
+    <q-drawer v-model="leftDrawerOpen" bordered>
       <q-list>
         <q-item-label header class="text-grey-8">Navigation</q-item-label>
         <SidebarLink
@@ -83,17 +97,20 @@
 import SidebarLink from "../components/SidebarLink.vue";
 
 export default {
-  name: "LoggedInLayout",
+  name: "StudentLoggedInLayout",
   components: {
     SidebarLink
   },
   data() {
     return {
       leftDrawerOpen: false,
+      darkModeOn: this.$q.localStorage.getItem("darkMode"),
       unseen: []
     };
   },
   created: function() {
+    this.setDarkMode();
+
     const user = this.$store.state.currentUser;
     this.$axios
       .get("/notifications/" + user.id + "/unread", {
@@ -108,6 +125,12 @@ export default {
   methods: {
     goToNotifPage() {
       this.$router.push("/student/notifications");
+    },
+    setDarkMode: function() {
+      if (this.darkModeOn === null) this.darkModeOn = false;
+
+      this.$q.dark.set(this.darkModeOn);
+      this.$q.localStorage.set("darkMode", this.darkModeOn);
     }
   }
 };


### PR DESCRIPTION
# Summary

This adds a dark mode using Quasar's Dark plugin. It looks pretty nice!

## Test Plan

![Screen Shot 2020-04-04 at  Apr 4   10 06 02 PM](https://user-images.githubusercontent.com/25532617/78465232-d6eee400-76c0-11ea-918b-4853785e8261.jpg)
![Screen Shot 2020-04-04 at  Apr 4   10 06 09 PM](https://user-images.githubusercontent.com/25532617/78465233-d8b8a780-76c0-11ea-9621-389a9a6792e8.jpg)
![Screen Shot 2020-04-04 at  Apr 4   10 06 18 PM](https://user-images.githubusercontent.com/25532617/78465236-da826b00-76c0-11ea-9cfe-7487906efd07.jpg)
![Screen Shot 2020-04-04 at  Apr 4   10 06 29 PM](https://user-images.githubusercontent.com/25532617/78465237-dce4c500-76c0-11ea-9f0f-bb86f405b76c.jpg)
![Screen Shot 2020-04-04 at  Apr 4   10 06 49 PM](https://user-images.githubusercontent.com/25532617/78465239-deae8880-76c0-11ea-94b2-cafca81f6fbd.jpg)


## Related Issues

closes #148 
