### PR TITLE
Add sorting for Coops and Notifications

### DIFF
--- a/Frontend/src/boot/common.js
+++ b/Frontend/src/boot/common.js
@@ -37,6 +37,41 @@ const common = {
     else return "black";
   },
   /*
+   * Used for sorting coop objects by term
+   */
+  compareCoopTerms: function(coop1, coop2) {
+    const term1 = `${coop1.courseOffering.season} ${coop1.courseOffering.year}`;
+    const term2 = `${coop2.courseOffering.season} ${coop2.courseOffering.year}`;
+
+    if (term1 === term2) return 0;
+    else {
+      const term1Split = term1.split(" ");
+      const term2Split = term2.split(" ");
+
+      if (parseInt(term1Split[1]) > parseInt(term2Split[1])) return 1;
+      else if (parseInt(term1Split[1]) < parseInt(term2Split[1])) return -1;
+      else {
+        // years are the same, compare by season
+        if (
+          (term1Split[0] === "WINTER" &&
+            (term2Split[0] === "SUMMER" || term2Split[0] === "FALL")) ||
+          (term1Split[0] === "SUMMER" && term2Split[0] === "FALL")
+        ) {
+          return -1;
+        } else {
+          return 1;
+        }
+      }
+    }
+  },
+  /*
+   * Used for sorting notifications by timestamp. Returns later notifications
+   * first.
+   */
+  compareNotificationTimestamps: function(notif1, notif2) {
+    return notif2.timeStamp - notif1.timeStamp;
+  },
+  /*
    * Converts a base64-encoded string to a blob; used for rendering PDFs
    *
    * Found on SO: https://stackoverflow.com/a/57767153

--- a/Frontend/src/boot/common.js
+++ b/Frontend/src/boot/common.js
@@ -65,8 +65,8 @@ const common = {
     }
   },
   /*
-   * Used for sorting notifications by timestamp. Returns later notifications
-   * first.
+   * Used for sorting notifications by timestamp. Returns most recent
+   * notifications first.
    */
   compareNotificationTimestamps: function(notif1, notif2) {
     return notif2.timeStamp - notif1.timeStamp;

--- a/Frontend/src/components/student/HomeUpcomingCoopsSection.vue
+++ b/Frontend/src/components/student/HomeUpcomingCoopsSection.vue
@@ -53,7 +53,7 @@ export default {
       const studentId = this.$store.state.currentUser.id;
       // get all upcoming coops for the currently logged in student
       this.$axios.get(`/students/${studentId}/upcoming-coops`).then(resp => {
-        this.coops = resp.data;
+        this.coops = resp.data.sort(this.$common.compareCoopTerms);
         this.loading = false;
       });
     }

--- a/Frontend/src/components/student/HomeUpcomingCoopsSection.vue
+++ b/Frontend/src/components/student/HomeUpcomingCoopsSection.vue
@@ -53,6 +53,7 @@ export default {
       const studentId = this.$store.state.currentUser.id;
       // get all upcoming coops for the currently logged in student
       this.$axios.get(`/students/${studentId}/upcoming-coops`).then(resp => {
+        // sort Coops by term
         this.coops = resp.data.sort(this.$common.compareCoopTerms);
         this.loading = false;
       });

--- a/Frontend/src/components/student/NotificationsList.vue
+++ b/Frontend/src/components/student/NotificationsList.vue
@@ -47,7 +47,10 @@ export default {
         }
       })
       .then(resp => {
-        this.notifications = resp.data;
+        // sort notifications by timestamp
+        this.notifications = resp.data.sort(
+          this.$common.compareNotificationTimestamps
+        );
         this.loading = false;
       });
     this.$axios.put(`/notifications/${user.id}/mark-as-read`, {

--- a/Frontend/src/layouts/AdminLoggedInLayout.vue
+++ b/Frontend/src/layouts/AdminLoggedInLayout.vue
@@ -32,12 +32,6 @@
                   />
                 </q-item-section>
               </q-item>
-              <q-item clickable v-close-popup>
-                <q-item-section>username</q-item-section>
-              </q-item>
-              <q-item clickable v-close-popup>
-                <q-item-section>Help</q-item-section>
-              </q-item>
               <q-separator />
               <q-item clickable v-close-popup>
                 <q-item-section>Settings</q-item-section>

--- a/Frontend/src/layouts/StudentLoggedInLayout.vue
+++ b/Frontend/src/layouts/StudentLoggedInLayout.vue
@@ -23,7 +23,13 @@
           icon="notifications"
           @click="goToNotifPage()"
         >
-          <q-badge color="white" text-color="red" floating transparent>
+          <q-badge
+            v-if="unseen.length > 0"
+            color="white"
+            text-color="red"
+            floating
+            transparent
+          >
             {{ unseen.length }}
           </q-badge>
         </q-btn>

--- a/Frontend/src/pages/admin/AdminCoopReviewPage.vue
+++ b/Frontend/src/pages/admin/AdminCoopReviewPage.vue
@@ -99,7 +99,8 @@ export default {
       this.$axios
         .get("/coops", { params: { status: "UNDER_REVIEW" } })
         .then(resp => {
-          this.newCoops = resp.data;
+          // sort in order of soonest terms first
+          this.newCoops = resp.data.sort(this.$common.compareCoopTerms);
           this.newCoopsLoading = false;
         });
     }


### PR DESCRIPTION
# Summary

Added some sorting functions in `common` so that Coops and Notifications can be sorted in the UI.

## Test Plan

Checked that things appeared in sorted order in the following places:
* The Student homepage in the "Upcoming Co-ops" section
* The Admin co-op review page for new co-ops
* The Student notification page

## Related Issues

closes #153, closes #155 
